### PR TITLE
Make frontend easier configurable and connect to backend

### DIFF
--- a/doc/src/.vuepress/config.js
+++ b/doc/src/.vuepress/config.js
@@ -72,6 +72,11 @@ module.exports = {
         sidebar: {
           "/documentation/": [
             {
+              title: "configuration",
+              collapsable: false,
+              children: ["architecture/configuration"],
+            },
+            {
               title: "Architektur",
               collapsable: false,
               children: ["architecture/overview", "architecture/adrs"],

--- a/doc/src/documentation/architecture/configuration.md
+++ b/doc/src/documentation/architecture/configuration.md
@@ -1,0 +1,22 @@
+# configuration
+
+Besides the spring configuration properties we created some for our own.
+
+All our properties are located in `application.yml` and start with `app`.
+
+## frontend
+
+The configuration is splitted into separate files:
+- `application-routing.yml` ... contains the route definitions for the gateway
+- `application-security.yml` ... contains the configuration for security
+
+The following `app`-properties were defined for the frontend:
+
+| propertyname                                | description                                                                                                                                      |
+|---------------------------------------------|--------------------------------------------------------------------------------------------------------------------------------------------------|
+| app.gateway.routing.sso.uri                 | URL to SSO for route with ID `sso`                                                                                                               |
+| app.gateway.routing.backend.uri             | URL to the backend service (route with ID `backend`)                                                                                             |
+| app.gateway.security.keycloak.issuer-uri    | URL to the sso realm. It used to get the sso config, for example. <br /> Alias for: `spring.security.oauth2.client.provider.keycloak.issuer-uri` |
+| app.gateway.security.keycloak.realm         | name of the realm in keycloak                                                                                                                    |
+| app.gateway.security.keycloak.client.id     | ID that is used by oauth2 client. <br /> Alias for: `spring.security.oauth2.client.registration.keycloak.client-id`                              |
+| app.gateway.security.keycloak.client.secret | secret that is used by oauth2 client. <br /> Alias for: `spring.security.oauth2.client.registration.keycloak.client-secret`                      |

--- a/praktikumsplaner-frontend/apigateway/src/main/resources/application-kon.yml
+++ b/praktikumsplaner-frontend/apigateway/src/main/resources/application-kon.yml
@@ -3,10 +3,6 @@ app:
   frontend-service: <YOUR_OPENSHIFT_KON_SERVICENAME>
 
 spring:
-
-  # Define the keycloak consolidation realm here; default is "intrap"
-  realm: intrap
-
   # spring cloud gateway config
   cloud:
     gateway:
@@ -24,38 +20,11 @@ spring:
             allowedHeaders: "*"
             allowCredentials: true
             maxAge: 3600
-      routes:
-        - id: sso
-          uri: https://ssotest.muenchen.de/
-          predicates:
-            - Path=/api/sso/userinfo
-          filters:
-            - RewritePath=/api/sso/userinfo, /auth/realms/${spring.realm}/protocol/openid-connect/userinfo
-        - id: backend
-          uri: http://${app.backend-service}:8080/
-          predicates:
-            - Path=/api/aa-a-backend-service/**
-          filters:
-            - RewritePath=/api/aa-a-backend-service/(?<urlsegments>.*), /$\{urlsegments}
-            - RemoveResponseHeader=WWW-Authenticate
       default-filters:
         - RemoveResponseHeader=Expires
         - RemoveRequestHeader=cookie
         - RemoveRequestHeader=x-xsrf-token
         - TokenRelay=
-
-  # security config
-  security:
-    oauth2:
-      client:
-        provider:
-          keycloak:
-            issuer-uri: https://ssotest.muenchen.de/auth/realms/${spring.realm}
-        registration:
-          keycloak:
-            client-id: aa-a
-            client-secret: 0b67133e-f4e0-42f6-b05f-7b51175969e8
-
   mvc:
     log-request-details: on
 

--- a/praktikumsplaner-frontend/apigateway/src/main/resources/application-local.yml
+++ b/praktikumsplaner-frontend/apigateway/src/main/resources/application-local.yml
@@ -1,10 +1,6 @@
 server:
   port: 8082
 spring:
-
-  # Define the local keycloak realm here
-  realm: <YOUR_LOCAL_REALM>
-
   # spring cloud gateway config
   cloud:
     gateway:
@@ -22,37 +18,10 @@ spring:
             allowedHeaders: "*"
             allowCredentials: true
             maxAge: 3600
-      routes:
-        - id: sso
-          uri: https://ssodev.muenchen.de/
-          predicates:
-            - Path=/api/sso/userinfo
-          filters:
-            - RewritePath=/api/sso/userinfo, /auth/realms/${spring.realm}/protocol/openid-connect/userinfo
-        - id: backend
-          uri: http://localhost:39146/
-          predicates:
-            - Path=/api/backend-service/**
-          filters:
-            - RewritePath=/api/backend-service/(?<urlsegments>.*), /$\{urlsegments}
-            - RemoveResponseHeader=WWW-Authenticate
       default-filters:
         - RemoveResponseHeader=Expires
         - RemoveRequestHeader=cookie
         - RemoveRequestHeader=x-xsrf-token
         - TokenRelay=
-
-  # security config
-  security:
-    oauth2:
-      client:
-        provider:
-          keycloak:
-            issuer-uri: https://ssodev.muenchen.de/auth/realms/${spring.realm}
-        registration:
-          keycloak:
-            client-id: aa-a
-            client-secret: 0b67133e-f4e0-42f6-b05f-7b51175969e8
-
   mvc:
     log-request-details: on

--- a/praktikumsplaner-frontend/apigateway/src/main/resources/application-prod.yml
+++ b/praktikumsplaner-frontend/apigateway/src/main/resources/application-prod.yml
@@ -3,10 +3,6 @@ app:
   frontend-service: <YOUR_OPENSHIFT_PROD_SERVICENAME>
 
 spring:
-
-  # Define the keycloak productive realm here
-  realm: muenchen.de
-
   # spring cloud gateway config
   cloud:
     gateway:
@@ -24,37 +20,11 @@ spring:
             allowedHeaders: "*"
             allowCredentials: true
             maxAge: 3600
-      routes:
-        - id: sso
-          uri: https://sso.muenchen.de/
-          predicates:
-            - Path=/api/sso/userinfo
-          filters:
-            - RewritePath=/api/sso/userinfo, /auth/realms/${spring.realm}/protocol/openid-connect/userinfo
-        - id: backend
-          uri: http://${app.backend-service}:8080/
-          predicates:
-            - Path=/api/aa-a-backend-service/**
-          filters:
-            - RewritePath=/api/aa-a-backend-service/(?<urlsegments>.*), /$\{urlsegments}
-            - RemoveResponseHeader=WWW-Authenticate
       default-filters:
         - RemoveResponseHeader=Expires
         - RemoveRequestHeader=cookie
         - RemoveRequestHeader=x-xsrf-token
         - TokenRelay=
-
-  # security config
-  security:
-    oauth2:
-      client:
-        provider:
-          keycloak:
-            issuer-uri: https://sso.muenchen.de/auth/realms/${spring.realm}
-        registration:
-          keycloak:
-            client-id: aa-a
-            client-secret: 0b67133e-f4e0-42f6-b05f-7b51175969e8
 
   mvc:
     log-request-details: false

--- a/praktikumsplaner-frontend/apigateway/src/main/resources/application-routing.yml
+++ b/praktikumsplaner-frontend/apigateway/src/main/resources/application-routing.yml
@@ -1,0 +1,18 @@
+spring:
+  # spring cloud gateway config
+  cloud:
+    gateway:
+      routes:
+        - id: sso
+          uri: ${app.gateway.routing.sso.uri}
+          predicates:
+            - Path=/api/sso/userinfo
+          filters:
+            - RewritePath=/api/sso/userinfo, /auth/realms/${app.gateway.security.keycloak.realm}/protocol/openid-connect/userinfo
+        - id: backend
+          uri: ${app.gateway.routing.backend.uri}
+          predicates:
+            - Path=/api/backend-service/**
+          filters:
+            - RewritePath=/api/backend-service/(?<urlsegments>.*), /$\{urlsegments}
+            - RemoveResponseHeader=WWW-Authenticate

--- a/praktikumsplaner-frontend/apigateway/src/main/resources/application-security.yml
+++ b/praktikumsplaner-frontend/apigateway/src/main/resources/application-security.yml
@@ -1,0 +1,12 @@
+spring:
+  # security config
+  security:
+    oauth2:
+      client:
+        provider:
+          keycloak:
+            issuer-uri: ${app.gateway.security.keycloak.issuer-uri}
+        registration:
+          keycloak:
+            client-id: ${app.gateway.security.keycloak.client.id}
+            client-secret: ${app.gateway.security.keycloak.client.secret}

--- a/praktikumsplaner-frontend/apigateway/src/main/resources/application.yml
+++ b/praktikumsplaner-frontend/apigateway/src/main/resources/application.yml
@@ -1,4 +1,9 @@
 spring:
+  profiles:
+    include:
+      - routing
+      - security
+
   application.name: @project.artifactId@
   banner.location: banner.txt
   main:
@@ -53,3 +58,18 @@ management:
       enabled: true
 
 config.map5xxto400: false
+
+app:
+  gateway:
+    routing:
+      sso:
+        uri: http://kubernetes.docker.internal:8100/
+      backend:
+        uri: http://localhost:39146/
+    security:
+      keycloak:
+        issuer-uri: http://kubernetes.docker.internal:8100/auth/realms/${app.security.keycloak.realm}
+        realm: praktikumsplaner
+        client:
+          id: praktikumsplaner
+          secret: top-secret

--- a/stack/local-docker-frontend.env
+++ b/stack/local-docker-frontend.env
@@ -1,6 +1,7 @@
 SPRING_PROFILES_ACTIVE=local
 realm=praktikumsplaner
-spring.realm=${realm}
-spring.security.oauth2.client.provider.keycloak.issuer-uri=http://kubernetes.docker.internal:8100/auth/realms/${realm}
-spring.security.oauth2.client.registration.keycloak.client-id=praktikumsplaner
-spring.security.oauth2.client.registration.keycloak.client-secret=top-secret
+app.gateway.routing.backend.uri=http://backend:39146/
+app.gateway.security.keycloak.realm=${realm}
+app.gateway.security.keycloak.issuer-uri=http://kubernetes.docker.internal:8100/auth/realms/${realm}
+app.gateway.security.keycloak.client.id=praktikumsplaner
+app.gateway.security.keycloak.client.secret=top-secret


### PR DESCRIPTION
**Description:**  

All import configurations option for local use or use in docker are part of default profile. The configuration options are described in the documentation.

The configuration for routes and keycloak are move to separated profiles to reuse them more easier.

With that change the connection of the frontend to the backend is established.

Notifying additional team members:

@mirrodi @MrSebastian @AnHo314

---
**Definition of Done (DoD):**

- [x] ~Unittests gepflegt~ no code changed
- [X] Dokumentation ist gepflegt: new page for configuration