### PR TITLE
🔀🚑️ fixed datatype for hibernate validation

### DIFF
--- a/praktikumsplaner-backend/src/main/resources/db/migration/V1.1__Create_NWK_Table_fix.sql
+++ b/praktikumsplaner-backend/src/main/resources/db/migration/V1.1__Create_NWK_Table_fix.sql
@@ -1,0 +1,2 @@
+alter table NWK alter column jahrgang type varchar(5);
+


### PR DESCRIPTION
**Description:**  

Fixed the datatype of column "jahrgang", because hibernate failed validation with the old datatype.

**Reference:**

Issue: #72

Notifying additional team members:

@mirrodi @MrSebastian @AnHo314
