### PR TITLE
🐛 fix keycloak url for backend

### DIFF
--- a/stack/local-docker-backend.env
+++ b/stack/local-docker-backend.env
@@ -3,5 +3,5 @@ spring.jpa.database-platform=org.hibernate.dialect.PostgreSQL95Dialect
 spring.h2.console.enabled=false
 SPRING_PROFILES_ACTIVE=local,db-postgres
 realm=praktikumsplaner
-spring.security.oauth2.resourceserver.jwt.jwk-set-uri=http://keycloak:8080/auth/realms/${realm}/protocol/openid-connect/certs
-security.oauth2.resource.user-info-uri=http://keycloak:8080/auth/realms/${realm}/protocol/openid-connect/userinfo
+spring.security.oauth2.resourceserver.jwt.jwk-set-uri=http://kubernetes.docker.internal:8100/auth/realms/${realm}/protocol/openid-connect/certs
+security.oauth2.resource.user-info-uri=http://kubernetes.docker.internal:8100/auth/realms/${realm}/protocol/openid-connect/userinfo


### PR DESCRIPTION
**Description:**  

url to sso in backend must be the same as the frontend uses to get the token

**Reference:**

Issue: #77 

Notifying additional team members:

@mirrodi @MrSebastian @AnHo314

---
**Definition of Done (DoD):**

- [x] ~Unittests gepflegt~ no code changes
- [X] ~Dokumentation ist gepflegt~ i dont think that any documentation is required for this