### PR TITLE
🔀🗃️ fixed vorlesungstage length to be able to register more than 2 days

### DIFF
--- a/praktikumsplaner-backend/src/main/resources/db/migration/V6__Create_NWK_Table_fix_vorlesungstage_length.sql
+++ b/praktikumsplaner-backend/src/main/resources/db/migration/V6__Create_NWK_Table_fix_vorlesungstage_length.sql
@@ -1,0 +1,2 @@
+alter table NWK alter column vorlesungstage type varchar(255);
+


### PR DESCRIPTION
**Description:**  

Vorlesungstage was varchar 27, which only supported 2 days max. Because the data is stored as whole days (e.g. MONDAY), this was too little. Changed length to 255 varchar to mitigate this.

**Reference**

Issue: #89 

Notifying additional team members:

@mirrodi @MrSebastian @AnHo314