### PR TITLE
🔀 🦺 changed maxLength rule

### DIFF
--- a/praktikumsplaner-frontend/frontend/src/composables/rules.ts
+++ b/praktikumsplaner-frontend/frontend/src/composables/rules.ts
@@ -5,7 +5,7 @@ export function useRules() {
 
     function maxLengthRule(length: number, message = "error") {
         return (value: string) =>
-            (value != null && value.length < length) || message;
+            (value != null && value.length <= length) || message;
     }
 
     function notEmptyDateRule(message = "error") {

--- a/praktikumsplaner-frontend/frontend/src/composables/rules.ts
+++ b/praktikumsplaner-frontend/frontend/src/composables/rules.ts
@@ -4,7 +4,7 @@ export function useRules() {
     }
 
     function maxLengthRule(length: number, message = "error") {
-        return (value: string) =>
+        return (value: string | null) =>
             (value != null && value.length <= length) || message;
     }
 

--- a/praktikumsplaner-frontend/frontend/tests/unit/rules.spec.ts
+++ b/praktikumsplaner-frontend/frontend/tests/unit/rules.spec.ts
@@ -69,9 +69,10 @@ describe("rules maxLength test", () => {
         const validationRules = useRules();
 
         const txtRule = validationRules.maxLengthRule(10, errorMessage);
+        const nullText = null;
 
         // eslint-disable-next-line @typescript-eslint/ban-ts-comment
         // @ts-ignore
-        expect(txtRule(null)).toBe(errorMessage);
+        expect(txtRule(nullText)).toBe(errorMessage);
     });
 });

--- a/praktikumsplaner-frontend/frontend/tests/unit/rules.spec.ts
+++ b/praktikumsplaner-frontend/frontend/tests/unit/rules.spec.ts
@@ -65,4 +65,13 @@ describe("rules maxLength test", () => {
 
         expect(txtRule(txt11)).toBe(errorMessage);
     });
+    it("tests maxLengthRule return error", () => {
+        const validationRules = useRules();
+
+        const txtRule = validationRules.maxLengthRule(10, errorMessage);
+
+        // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+        // @ts-ignore
+        expect(txtRule(null)).toBe(errorMessage);
+    });
 });

--- a/praktikumsplaner-frontend/frontend/tests/unit/rules.spec.ts
+++ b/praktikumsplaner-frontend/frontend/tests/unit/rules.spec.ts
@@ -69,10 +69,7 @@ describe("rules maxLength test", () => {
         const validationRules = useRules();
 
         const txtRule = validationRules.maxLengthRule(10, errorMessage);
-        const nullText = null;
 
-        // eslint-disable-next-line @typescript-eslint/ban-ts-comment
-        // @ts-ignore
-        expect(txtRule(nullText)).toBe(errorMessage);
+        expect(txtRule(null)).toBe(errorMessage);
     });
 });

--- a/praktikumsplaner-frontend/frontend/tests/unit/rules.spec.ts
+++ b/praktikumsplaner-frontend/frontend/tests/unit/rules.spec.ts
@@ -1,8 +1,7 @@
 import { useRules } from "@/composables/rules";
 import { describe } from "vitest";
-
-describe("rules test", () => {
-    const errorMessage = "Error";
+const errorMessage = "Error";
+describe("rules fileFormat test", () => {
     it("tests fileFormatRules return true", () => {
         const validationRules = useRules();
 
@@ -47,5 +46,23 @@ describe("rules test", () => {
         // eslint-disable-next-line @typescript-eslint/ban-ts-comment
         // @ts-ignore
         expect(txtRule(undefined)).toBe(errorMessage);
+    });
+});
+describe("rules maxLength test", () => {
+    it("tests maxLengthRule return true", () => {
+        const validationRules = useRules();
+
+        const txtRule = validationRules.maxLengthRule(10, errorMessage);
+        const txt10 = "Lorem ipsu";
+
+        expect(txtRule(txt10)).toBe(true);
+    });
+    it("tests maxLengthRule return error", () => {
+        const validationRules = useRules();
+
+        const txtRule = validationRules.maxLengthRule(10, errorMessage);
+        const txt11 = "Lorem ipsum";
+
+        expect(txtRule(txt11)).toBe(errorMessage);
     });
 });


### PR DESCRIPTION
changed maxLength rule to include last char, e.g. maxlength=5, 5 chars allowed and not 4

**Reference:**

fixes #96 

Notifying additional team members:

@mirrodi @MrSebastian @AnHo314
