### PR TITLE
🐛🔀 Fixed showing programmierkenntnisse if no programmierkenntnisse 

### DIFF
--- a/praktikumsplaner-frontend/frontend/src/components/Assignment/PraktikumsstelleCard.vue
+++ b/praktikumsplaner-frontend/frontend/src/components/Assignment/PraktikumsstelleCard.vue
@@ -125,7 +125,7 @@ function getCardDetailText(stelle: Praktikumsstelle): string {
         stelle.dringlichkeit.charAt(0).toUpperCase() +
         stelle.dringlichkeit.slice(1).toLowerCase();
     cardText += "Dringlichkeit: " + dringlichkeit + "\n";
-    if (stelle.programmierkenntnisse !== undefined) {
+    if (stelle.programmierkenntnisse) {
         cardText += "Programmierkenntnisse: ";
         switch (stelle.programmierkenntnisse) {
             case "true":


### PR DESCRIPTION
**Description:**  

Wenn keine Programmierkenntnisse gegeben waren bei einer Azubistelle, dann wird jetzt auch nicht mehr "Programmierkenntnisse: " angezeigt

**Reference:**

Issue: #162 

Notifying additional team members:

@mirrodi @MrSebastian @AnHo314