### PR TITLE
🔀🐛 Navigation fixed to work with createWebHistory

### DIFF
--- a/praktikumsplaner-frontend/apigateway/src/main/java/de/muenchen/oss/praktikumsplaner/configuration/GuiConfiguration.java
+++ b/praktikumsplaner-frontend/apigateway/src/main/java/de/muenchen/oss/praktikumsplaner/configuration/GuiConfiguration.java
@@ -19,7 +19,6 @@ import org.springframework.web.reactive.function.server.ServerResponse;
 
 /**
  * This class supplies the endpoint which provides the gui.
- *
  * The default path to the gui entry point is "classpath:/static/index.html".
  */
 @Configuration
@@ -36,7 +35,7 @@ public class GuiConfiguration {
     public RouterFunction<ServerResponse> indexRouter(
             @Value("classpath:/static/index.html") final Resource indexHtml) {
         log.debug("Location gui entry point: {}", indexHtml);
-        return route(GET("/"),
+        return route(GET("/*"),
                 request -> ok().contentType(MediaType.TEXT_HTML)
                         .bodyValue(indexHtml));
     }


### PR DESCRIPTION
**Description:**  

Since the vue3 upgrade the navigation failed when a reload was triggered by the user (ex. STRG+R, F5, browser-reload-button)
When navigating via the navigation bar it worked.
This should be fixed now by routing all requests to the index.html

**Reference:**

Issue: #230 

Notifying additional team members:

@mirrodi @MrSebastian @AnHo314