### PR TITLE
🔀🐛  removed wrong newlines in warnings dialog

### DIFF
--- a/praktikumsplaner-frontend/frontend/src/composables/warningGenerator.ts
+++ b/praktikumsplaner-frontend/frontend/src/composables/warningGenerator.ts
@@ -46,7 +46,7 @@ export function useWarnings() {
                 nwk.studiengang +
                 " Student*in auf eine " +
                 stelle.studiengang +
-                " Stelle setzen?\n";
+                " Stelle setzen?";
             warnings.push(new Warning("", warningText));
         }
 
@@ -94,7 +94,7 @@ export function useWarnings() {
                 warningText +=
                     expectedSemesters[expectedSemesters.length - 1] +
                     ". Semester";
-                warningText += " erwartet wird.\n";
+                warningText += " erwartet wird.";
                 warnings.push(new Warning("", warningText));
             }
         }


### PR DESCRIPTION
**Description:**  

The warning dialog in the assignview showed some newlines that should not be there. They are removed with this PR.

**Reference:**

Issue: #231 

Notifying additional team members:

@mirrodi @MrSebastian @AnHo314
