### PR TITLE
🔀🐛 Fix unable to unassign due to too long name

### DIFF
--- a/praktikumsplaner-frontend/frontend/src/components/assign/PraktikumsstelleCardZuweisung.vue
+++ b/praktikumsplaner-frontend/frontend/src/components/assign/PraktikumsstelleCardZuweisung.vue
@@ -260,6 +260,15 @@ function getNwkColor(nwk: Nwk): string {
     bottom: 10px;
     right: 10px;
 }
+
+/*
+This code can be updated when the Firefox version is updated.
+In some browsers the pseudo-class :has() is not yet supported.  A possible implementation could look like this.
+
+.v-chip__content:has(> .chip-text) {
+    overflow: hidden;
+}
+ */
 @media only screen and (max-width: 1000px) {
     .chip-text {
         max-width: 10vw !important;

--- a/praktikumsplaner-frontend/frontend/src/components/assign/PraktikumsstelleCardZuweisung.vue
+++ b/praktikumsplaner-frontend/frontend/src/components/assign/PraktikumsstelleCardZuweisung.vue
@@ -260,7 +260,17 @@ function getNwkColor(nwk: Nwk): string {
     bottom: 10px;
     right: 10px;
 }
+@media only screen and (max-width: 1000px) {
+    .chip-text {
+        max-width: 10vw !important;
+    }
+}
+@media only screen and (max-width: 1900px) and (min-width: 1000px) {
+    .chip-text {
+        max-width: 15vw !important;
+    }
+}
 .chip-text {
-    max-width: 20vw;
+    max-width: 25vw;
 }
 </style>

--- a/praktikumsplaner-frontend/frontend/src/components/assign/PraktikumsstelleCardZuweisung.vue
+++ b/praktikumsplaner-frontend/frontend/src/components/assign/PraktikumsstelleCardZuweisung.vue
@@ -44,7 +44,10 @@
                     v-if="assignedNwk && !loading"
                     :color="getNwkColor(assignedNwk)"
                     variant="flat"
-                    >{{ `${assignedNwk.vorname} ${assignedNwk.nachname}` }}
+                >
+                    <span class="text-truncate chip-text">
+                        {{ `${assignedNwk.vorname} ${assignedNwk.nachname}` }}
+                    </span>
                     <template #close>
                         <v-icon
                             icon="mdi-close-circle"
@@ -254,5 +257,10 @@ function getNwkColor(nwk: Nwk): string {
     position: absolute;
     bottom: 10px;
     right: 10px;
+}
+.chip-text {
+    min-width: 30vmin;
+    max-width: 50vmin;
+    width: 90%;
 }
 </style>

--- a/praktikumsplaner-frontend/frontend/src/components/assign/PraktikumsstelleCardZuweisung.vue
+++ b/praktikumsplaner-frontend/frontend/src/components/assign/PraktikumsstelleCardZuweisung.vue
@@ -44,10 +44,12 @@
                     v-if="assignedNwk && !loading"
                     :color="getNwkColor(assignedNwk)"
                     variant="flat"
+                    class="chip"
                 >
                     <span class="text-truncate chip-text">
                         {{ `${assignedNwk.vorname} ${assignedNwk.nachname}` }}
                     </span>
+
                     <template #close>
                         <v-icon
                             icon="mdi-close-circle"
@@ -259,7 +261,6 @@ function getNwkColor(nwk: Nwk): string {
     right: 10px;
 }
 .chip-text {
-    min-width: 30vmin;
-    max-width: 45vmin;
+    max-width: 20vw;
 }
 </style>

--- a/praktikumsplaner-frontend/frontend/src/components/assign/PraktikumsstelleCardZuweisung.vue
+++ b/praktikumsplaner-frontend/frontend/src/components/assign/PraktikumsstelleCardZuweisung.vue
@@ -260,7 +260,7 @@ function getNwkColor(nwk: Nwk): string {
 }
 .chip-text {
     min-width: 30vmin;
-    max-width: 50vmin;
+    max-width: 45vmin;
     width: 90%;
 }
 </style>

--- a/praktikumsplaner-frontend/frontend/src/components/assign/PraktikumsstelleCardZuweisung.vue
+++ b/praktikumsplaner-frontend/frontend/src/components/assign/PraktikumsstelleCardZuweisung.vue
@@ -261,6 +261,5 @@ function getNwkColor(nwk: Nwk): string {
 .chip-text {
     min-width: 30vmin;
     max-width: 45vmin;
-    width: 90%;
 }
 </style>


### PR DESCRIPTION
**Description:**  

Possible to unassign nwks in the assignview, even if the name is too long.

**Reference:**

Issue: #245

Notifying additional team members:

@mirrodi @MrSebastian @AnHo314
