### PR TITLE
Revert "Update postgres Docker tag to v17"

### DIFF
--- a/stack/docker-compose.yml
+++ b/stack/docker-compose.yml
@@ -39,7 +39,7 @@ services:
       - keycloak
 
   postgres-backend:
-    image: postgres:17.0
+    image: postgres:13.2
     container_name: postgres-backend
     environment:
       POSTGRES_DB: praktikumsplaner
@@ -84,7 +84,7 @@ services:
       - keycloak
 
   postgres-keycloak:
-    image: postgres:17.0
+    image: postgres:13.2
     container_name: postgres-keycloak
     environment:
       POSTGRES_DB: keycloak


### PR DESCRIPTION
Reverts it-at-m/Praktikumsplaner#375

Caused by: org.springframework.beans.factory.BeanCreationException: Error creating bean with name 'flywayInitializer' defined in class path resource [org/springframework/boot/autoconfigure/flyway/FlywayAutoConfiguration$FlywayConfiguration.class]: Unsupported Database: PostgreSQL 17.0