### PR TITLE
Omit Resolved Config 4 Renovate

### DIFF
--- a/doc/.npmrc
+++ b/doc/.npmrc
@@ -1,0 +1,1 @@
+omit-lockfile-registry-resolved=true

--- a/praktikumsplaner-frontend/.npmrc
+++ b/praktikumsplaner-frontend/.npmrc
@@ -1,0 +1,1 @@
+omit-lockfile-registry-resolved=true


### PR DESCRIPTION
Hopefully Renovate doesn't add `resolved` to package-lock anymore

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated npm configuration to streamline lockfile generation by omitting extraneous registry metadata, improving consistency across environments and reducing noise in version control.
  * Harmonized install behavior across project areas to minimize unnecessary lockfile diffs and maintain cleaner change histories.
  * No user-facing impact: application functionality, builds, and installs remain unchanged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->