### PR TITLE
chore/fix maven and npm release

### DIFF
--- a/praktikumsplaner-backend/pom.xml
+++ b/praktikumsplaner-backend/pom.xml
@@ -17,7 +17,7 @@
 
     <name>praktikumsplaner-backend</name>
     <description>Backend service of the Praktikumsplaner</description>
-    <url>scm:git:https://github.com/it-at-m/Praktikumsplaner.git</url>
+    <url>https://github.com/it-at-m/Praktikumsplaner</url>
     <licenses>
         <license>
             <name>MIT</name>

--- a/praktikumsplaner-backend/pom.xml
+++ b/praktikumsplaner-backend/pom.xml
@@ -13,9 +13,31 @@
 
     <groupId>de.muenchen.oss.praktikumsplaner</groupId>
     <artifactId>praktikumsplaner-backend</artifactId>
-    <version>0.0.1-SNAPSHOT</version>
-    <name>praktikumsplaner-backend</name>
+    <version>0.29.0-SNAPSHOT</version>
 
+    <name>praktikumsplaner-backend</name>
+    <description>Backend service of the Praktikumsplaner</description>
+    <url>scm:git:https://github.com/it-at-m/Praktikumsplaner.git</url>
+    <licenses>
+        <license>
+            <name>MIT</name>
+            <url>https://opensource.org/licenses/MIT</url>
+            <distribution>repo</distribution>
+        </license>
+    </licenses>
+    <scm>
+        <url>https://github.com/it-at-m/Praktikumsplaner.git</url>
+        <connection>scm:git:https://github.com/it-at-m/Praktikumsplaner.git</connection>
+        <developerConnection>scm:git:https://github.com/it-at-m/Praktikumsplaner.git</developerConnection>
+        <tag>HEAD</tag>
+    </scm>
+    <developers>
+        <developer>
+            <organization>it@M</organization>
+            <email>opensource@muenchen.de</email>
+            <url>https://github.com/it-at-m</url>
+        </developer>
+    </developers>
 
     <properties>
         <java.version>21</java.version>

--- a/praktikumsplaner-frontend/package.json
+++ b/praktikumsplaner-frontend/package.json
@@ -1,6 +1,6 @@
 {
     "name": "praktikumsplaner-frontend-frontend",
-    "version": "0.1.0",
+    "version": "0.28.0",
     "private": true,
     "scripts": {
         "security": "vite --mode developmentSecurity",


### PR DESCRIPTION
**Description:**  

- chore: fix maven and npm release by adding missing fields and correct version


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Aligned and bumped project version numbers for backend and frontend releases.
  * Added standard project metadata: description, project URL, MIT license, source repository info, and developer/organization contact details for clearer attribution and governance.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->