### PR TITLE
fix(backend): Excel export jahr column

### DIFF
--- a/praktikumsplaner-backend/src/main/java/de/muenchen/oss/praktikumsplaner/service/ExcelExportService.java
+++ b/praktikumsplaner-backend/src/main/java/de/muenchen/oss/praktikumsplaner/service/ExcelExportService.java
@@ -25,6 +25,7 @@ import java.util.Base64;
 import java.util.List;
 import java.util.Set;
 import java.util.StringJoiner;
+import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
 import org.apache.poi.ss.usermodel.Row;
 import org.apache.poi.xssf.usermodel.XSSFSheet;
@@ -240,41 +241,30 @@ public class ExcelExportService {
     }
 
     private static String ausbildungsjahrToStringConverter(final Set<Ausbildungsjahr> ausbildungsjahr) {
-
-        if (ausbildungsjahr.containsAll(List.of(JAHR1, JAHR2, JAHR3))) {
+        if (ausbildungsjahr.containsAll(List.of(Ausbildungsjahr.values()))) {
             return "";
         }
 
-        if (ausbildungsjahr.contains(JAHR3)) {
-            return "vorrangig 3. Jahr";
-        }
-        if (ausbildungsjahr.contains(JAHR2)) {
-            return "vorrangig 2. Jahr";
-        }
-        if (ausbildungsjahr.contains(JAHR1)) {
-            return "vorrangig 1. Jahr";
-        }
-
-        return "";
+        return "vorrangig %s Lehrjahr".formatted(ausbildungsjahr.stream().map(i -> switch (i) {
+        case JAHR1 -> "1.";
+        case JAHR2 -> "2.";
+        case JAHR3 -> "3.";
+        }).sorted().collect(Collectors.joining(", ")));
     }
 
     private static String studiensemesterToStringConverter(final Set<Studiensemester> studiensemester) {
-
-        if (studiensemester.containsAll(List.of(SEMESTER1, SEMESTER2, SEMESTER3, SEMESTER4, SEMESTER5, SEMESTER6))) {
+        if (studiensemester.containsAll(List.of(Studiensemester.values()))) {
             return "";
         }
 
-        if (studiensemester.contains(SEMESTER5) || studiensemester.contains(SEMESTER6)) {
-            return "vorrangig 3. Jahr";
-        }
-        if (studiensemester.contains(SEMESTER3) || studiensemester.contains(SEMESTER4)) {
-            return "vorrangig 2. Jahr";
-        }
-        if (studiensemester.contains(SEMESTER1) || studiensemester.contains(SEMESTER2)) {
-            return "vorrangig 1. Jahr";
-        }
-
-        return "";
+        return "vorrangig %s Semester".formatted(studiensemester.stream().map(i -> switch (i) {
+        case SEMESTER1 -> "1.";
+        case SEMESTER2 -> "2.";
+        case SEMESTER3 -> "3.";
+        case SEMESTER4 -> "4.";
+        case SEMESTER5 -> "5.";
+        case SEMESTER6 -> "6.";
+        }).sorted().collect(Collectors.joining(", ")));
     }
 
     private static Row getRow(final XSSFSheet sheet, final int i) {

--- a/praktikumsplaner-backend/src/test/java/de/muenchen/oss/praktikumsplaner/service/ExcelExportServiceTest.java
+++ b/praktikumsplaner-backend/src/test/java/de/muenchen/oss/praktikumsplaner/service/ExcelExportServiceTest.java
@@ -61,7 +61,7 @@ public class ExcelExportServiceTest {
             assertThat(ausbildungsSheet.getRow(3).getCell(8).getStringCellValue(), not(containsString("Namentliche Anforderung:")));
             assertThat(ausbildungsSheet.getRow(3).getCell(8).getStringCellValue(), containsString("Wuensche 1"));
             assertEquals("Nein", ausbildungsSheet.getRow(3).getCell(9).getStringCellValue());
-            assertEquals("vorrangig 1. Jahr", ausbildungsSheet.getRow(3).getCell(13).getStringCellValue());
+            assertEquals("vorrangig 2., 3. Lehrjahr", ausbildungsSheet.getRow(3).getCell(13).getStringCellValue());
             assertEquals(ausbildungsPraktikumsstellen.getFirst().dringlichkeit().name(), ausbildungsSheet.getRow(3).getCell(12).getStringCellValue());
             assertEquals(ausbildungsPraktikumsstellen.getFirst().ausbildungsrichtung().name(), ausbildungsSheet.getRow(3).getCell(14).getStringCellValue());
             assertEquals("Praktikumsplatz", ausbildungsSheet.getRow(3).getCell(11).getStringCellValue());
@@ -82,7 +82,7 @@ public class ExcelExportServiceTest {
             assertThat(studiumsSheet.getRow(3).getCell(8).getStringCellValue(), containsString("Wuensche 3"));
             assertEquals("Ja", studiumsSheet.getRow(3).getCell(10).getStringCellValue());
             assertEquals(studiumsPraktikumsstellen.getFirst().dringlichkeit().name(), studiumsSheet.getRow(3).getCell(12).getStringCellValue());
-            assertEquals("vorrangig 1. Jahr", studiumsSheet.getRow(3).getCell(13).getStringCellValue());
+            assertEquals("vorrangig 4., 5. Semester", studiumsSheet.getRow(3).getCell(13).getStringCellValue());
             assertEquals(studiumsPraktikumsstellen.getFirst().studiengang().name(), studiumsSheet.getRow(3).getCell(14).getStringCellValue());
             assertEquals("Praktikumsplatz", studiumsSheet.getRow(3).getCell(11).getStringCellValue());
             assertEquals(studiumsPraktikumsstellen.getFirst().assignedNwk().nachname(), studiumsSheet.getRow(3).getCell(15).getStringCellValue());
@@ -127,7 +127,7 @@ public class ExcelExportServiceTest {
     private List<AusbildungsPraktikumsstelleDto> getTestListOfAusbildungsPraktikumsstelleDto() {
         return List.of(
                 helper.createPraktikumsstelleDto(helper.createAusbildungsPraktikumsstelleEntity("ITM-DS1", "Ausbilder 1", "a@b.c", "Taetigkeiten 1",
-                        "Wuensche 1", Dringlichkeit.DRINGEND, Set.of(Ausbildungsjahr.JAHR1), Ausbildungsrichtung.FISI, false, true, null,
+                        "Wuensche 1", Dringlichkeit.DRINGEND, Set.of(Ausbildungsjahr.JAHR2, Ausbildungsjahr.JAHR3), Ausbildungsrichtung.FISI, false, true, null,
                         helper.createNwkEntity("Vorname 1", "Nachname 1", null, Ausbildungsrichtung.FISI, "22/23", null, true))),
                 helper.createPraktikumsstelleDto(helper.createAusbildungsPraktikumsstelleEntity("ITM-DS2", "Ausbilder 2", "a@b.c", "Taetigkeiten 2",
                         null, Dringlichkeit.DRINGEND, Set.of(Ausbildungsjahr.JAHR2), Ausbildungsrichtung.FISI, true, false, null,
@@ -137,7 +137,7 @@ public class ExcelExportServiceTest {
     private List<StudiumsPraktikumsstelleDto> getTestListOfStudiumsPraktikumsstelleDto() {
         return List.of(
                 helper.createPraktikumsstelleDto(helper.createStudiumsPraktikumsstelleEntity("ITM-DS3", "Ausbilder 3", "a@b.c", "Taetigkeiten 3",
-                        "Wuensche 3", Dringlichkeit.DRINGEND, Set.of(Studiensemester.SEMESTER1), Studiengang.BWI, "true", null,
+                        "Wuensche 3", Dringlichkeit.DRINGEND, Set.of(Studiensemester.SEMESTER5, Studiensemester.SEMESTER4), Studiengang.BWI, "true", null,
                         helper.createNwkEntity("Vorname 3", "Nachname 3", Studiengang.BSC, null, "22/23", null, true))),
                 helper.createPraktikumsstelleDto(helper.createStudiumsPraktikumsstelleEntity("ITM-DS4", "Ausbilder 4", "a@b.c", "Taetigkeiten 4",
                         null, Dringlichkeit.ZWINGEND, Set.of(Studiensemester.SEMESTER2), Studiengang.VI, "false", null,


### PR DESCRIPTION
**Description:**  

- fix(backend): refactor construction of Excel export "Ausbildungsjahr"/"Studienjahr" column

---
**Definition of Done (DoD):**

- [x] Unittests gepflegt

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed Excel export to display all selected apprenticeship years/semesters instead of only showing priority-based labels. Years and semesters now appear as a comma-separated, formatted list.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->