### PR TITLE
feat(frontend): add data-test attributes for UI testing

### DIFF
--- a/docs/documentation/architecture/adr/adr010-data-test-attributes.md
+++ b/docs/documentation/architecture/adr/adr010-data-test-attributes.md
@@ -6,8 +6,9 @@
 
 ## Context
 
-The UI is to be tested end-to-end with Selenium. Selenium locates elements via
-selectors. Selecting elements by CSS classes (e.g. Vuetify utility classes),
+The UI is to be tested end-to-end with automated browser test tools. Such
+tools locate elements via selectors. Selecting elements by CSS classes (e.g.
+Vuetify utility classes),
 tag structure or visible text is brittle: class names change with styling,
 the DOM structure produced by Vuetify changes between versions, and visible
 text changes with i18n or copy edits. Every such change silently breaks the
@@ -26,7 +27,7 @@ Every relevant UI element receives a dedicated `data-test` attribute.
 - Attribute name: **`data-test`** (not `id`, not `data-testid`, not `data-cy`).
   Using `data-test` keeps a clear separation between production concerns
   (`id`, `class`) and the test contract, and works with a simple
-  `[data-test='...']` selector in Selenium.
+  `[data-test='...']` selector in common UI test tools.
 - The values are centrally defined in
   `praktikumsplaner-frontend/src/testIds.ts` as typed constants. Templates
   reference these constants instead of inlining string literals, so that the
@@ -46,7 +47,7 @@ Every relevant UI element receives a dedicated `data-test` attribute.
 
 Vuetify components pass unknown attributes (fallthrough attributes) to their
 root element. A `data-test` on `<v-btn>` / `<v-text-field>` therefore appears
-on the rendered root element. For inputs, Selenium can select the input via
+on the rendered root element. For inputs, test tools can select the input via
 `[data-test='...'] input` when the raw `<input>` is required.
 
 Reusable wrapper components (e.g. `NameInput`, `DienststellenInput`) carry a

--- a/docs/documentation/architecture/adr/adr010-data-test-attributes.md
+++ b/docs/documentation/architecture/adr/adr010-data-test-attributes.md
@@ -1,0 +1,69 @@
+# ADR-010 use data-test attributes for UI testing
+
+## Status
+
+<adr-status status='accepted' />
+
+## Context
+
+The UI is to be tested end-to-end with Selenium. Selenium locates elements via
+selectors. Selecting elements by CSS classes (e.g. Vuetify utility classes),
+tag structure or visible text is brittle: class names change with styling,
+the DOM structure produced by Vuetify changes between versions, and visible
+text changes with i18n or copy edits. Every such change silently breaks the
+UI tests.
+
+We therefore need selectors that are:
+
+- stable across styling, refactoring and library upgrades,
+- independent of visible text,
+- explicitly maintained as a test contract.
+
+## Decision
+
+Every relevant UI element receives a dedicated `data-test` attribute.
+
+- Attribute name: **`data-test`** (not `id`, not `data-testid`, not `data-cy`).
+  Using `data-test` keeps a clear separation between production concerns
+  (`id`, `class`) and the test contract, and works with a simple
+  `[data-test='...']` selector in Selenium.
+- The values are centrally defined in
+  `praktikumsplaner-frontend/src/testIds.ts` as typed constants. Templates
+  reference these constants instead of inlining string literals, so that the
+  IDs are discoverable, refactor-safe and free of typos.
+- Granularity: interactive elements (buttons, inputs, selects, checkboxes,
+  radio groups, file inputs) **and** structural anchor elements (dialogs,
+  data tables and their rows, navigation entries, page titles, list cards,
+  snackbar/error dialogs) are instrumented. Purely decorative elements
+  (icons, tooltips, spacers) are not.
+- Naming convention: kebab-case, hierarchical from area to element, in the
+  form `<area>-<component>-<element>`, e.g.
+  `nwk-create-dialog-open-btn`, `praktikumsstelle-dienststelle-input`,
+  `data-table-search`. The convention is documented in the
+  [UI test IDs guide](../../guides/ui-test-ids/index.md).
+
+### How `data-test` reaches the DOM
+
+Vuetify components pass unknown attributes (fallthrough attributes) to their
+root element. A `data-test` on `<v-btn>` / `<v-text-field>` therefore appears
+on the rendered root element. For inputs, Selenium can select the input via
+`[data-test='...'] input` when the raw `<input>` is required.
+
+Reusable wrapper components (e.g. `NameInput`, `DienststellenInput`) carry a
+fixed `data-test` value. This is safe because two instances of the same
+wrapper are never visible at the same time (dialogs and views are mutually
+exclusive on screen).
+
+### Todo
+
+- Apply `data-test` to all existing views and components.
+- New components must add `data-test` for interactive and anchor elements and
+  register the ID in `testIds.ts`.
+
+## Consequences
+
+- UI tests become robust against restyling, DOM refactoring and Vuetify
+  upgrades.
+- There is one central, typed source of truth for all test IDs.
+- Every new interactive element requires a small extra step (adding a constant
+  and referencing it), which has to be enforced in review.

--- a/docs/documentation/architecture/adrs.md
+++ b/docs/documentation/architecture/adrs.md
@@ -14,3 +14,4 @@ The following ADRs exist:
 - [ADR-007 send errormessage](adr/adr007-send-errormessage.md)
 - [ADR-008 security roles](adr/adr008-security-roles.md)
 - [ADR-009 action reload](adr/adr009-action-reload.md)
+- [ADR-010 use data-test attributes for UI testing](adr/adr010-data-test-attributes.md)

--- a/docs/documentation/guides/ui-test-ids/index.md
+++ b/docs/documentation/guides/ui-test-ids/index.md
@@ -1,7 +1,7 @@
 # UI Test IDs (`data-test`)
 
 This guide describes how the frontend is instrumented for automated UI tests
-(e.g. Selenium). The underlying decision is documented in
+(e.g. browser-based end-to-end tools). The underlying decision is documented in
 [ADR-010](../../architecture/adr/adr010-data-test-attributes.md).
 
 ## Goal
@@ -12,13 +12,13 @@ that end-to-end tests do not break when styling, DOM structure or copy changes.
 ## The attribute
 
 - We use the attribute **`data-test`**.
-- Selenium selects elements via the CSS selector `[data-test='<id>']`.
+- Test tools select elements via the CSS selector `[data-test='<id>']`.
 - For raw input access use `[data-test='<id>'] input`,
   `[data-test='<id>'] textarea` etc., because Vuetify renders a wrapper around
   the native control.
 
 ```java
-// Selenium (Java) example
+// Example with a CSS selector based UI test tool
 driver.findElement(By.cssSelector("[data-test='nwk-create-dialog-open-btn']")).click();
 driver.findElement(By.cssSelector("[data-test='nwk-vorname-input'] input")).sendKeys("Max");
 ```

--- a/docs/documentation/guides/ui-test-ids/index.md
+++ b/docs/documentation/guides/ui-test-ids/index.md
@@ -51,13 +51,13 @@ discoverable, typo-free and refactor-safe.
 
 Examples:
 
-| Constant                         | Rendered `data-test` value       |
-| -------------------------------- | -------------------------------- |
-| `testIds.nav.nachwuchskraefte`   | `nav-nachwuchskraefte`           |
-| `testIds.nwk.createDialogOpenBtn`| `nwk-create-dialog-open-btn`     |
-| `testIds.nwk.vornameInput`       | `nwk-vorname-input`              |
-| `testIds.dataTable.search`       | `data-table-search`             |
-| `testIds.dialog.yesNoYesBtn`     | `yesno-dialog-yes-btn`          |
+| Constant                          | Rendered `data-test` value   |
+| --------------------------------- | ---------------------------- |
+| `testIds.nav.nachwuchskraefte`    | `nav-nachwuchskraefte`       |
+| `testIds.nwk.createDialogOpenBtn` | `nwk-create-dialog-open-btn` |
+| `testIds.nwk.vornameInput`        | `nwk-vorname-input`          |
+| `testIds.common.dataTableSearch`  | `data-table-search`          |
+| `testIds.dialog.yesNoYesBtn`      | `yesno-dialog-yes-btn`       |
 
 ## What gets an ID
 

--- a/docs/documentation/guides/ui-test-ids/index.md
+++ b/docs/documentation/guides/ui-test-ids/index.md
@@ -1,0 +1,87 @@
+# UI Test IDs (`data-test`)
+
+This guide describes how the frontend is instrumented for automated UI tests
+(e.g. Selenium). The underlying decision is documented in
+[ADR-010](../../architecture/adr/adr010-data-test-attributes.md).
+
+## Goal
+
+Provide **stable, text-independent selectors** for every relevant UI element so
+that end-to-end tests do not break when styling, DOM structure or copy changes.
+
+## The attribute
+
+- We use the attribute **`data-test`**.
+- Selenium selects elements via the CSS selector `[data-test='<id>']`.
+- For raw input access use `[data-test='<id>'] input`,
+  `[data-test='<id>'] textarea` etc., because Vuetify renders a wrapper around
+  the native control.
+
+```java
+// Selenium (Java) example
+driver.findElement(By.cssSelector("[data-test='nwk-create-dialog-open-btn']")).click();
+driver.findElement(By.cssSelector("[data-test='nwk-vorname-input'] input")).sendKeys("Max");
+```
+
+## Central source of truth
+
+All IDs live in `praktikumsplaner-frontend/src/testIds.ts` as typed constants
+grouped by area. Templates import `testIds` and bind them:
+
+```vue
+<script setup lang="ts">
+import { testIds } from "@/testIds";
+</script>
+
+<template>
+  <v-btn :data-test="testIds.nwk.createDialogOpenBtn" />
+</template>
+```
+
+Never inline raw `data-test` string literals in a template. Always add a
+constant to `testIds.ts` first and reference it. This keeps the IDs
+discoverable, typo-free and refactor-safe.
+
+## Naming convention
+
+- kebab-case values.
+- Hierarchical, from area to concrete element: `<area>-<component>-<element>`.
+- Suffix by element type where helpful: `-btn`, `-input`, `-select`,
+  `-checkbox`, `-radio`, `-dialog`, `-table`, `-row`, `-link`.
+
+Examples:
+
+| Constant                         | Rendered `data-test` value       |
+| -------------------------------- | -------------------------------- |
+| `testIds.nav.nachwuchskraefte`   | `nav-nachwuchskraefte`           |
+| `testIds.nwk.createDialogOpenBtn`| `nwk-create-dialog-open-btn`     |
+| `testIds.nwk.vornameInput`       | `nwk-vorname-input`              |
+| `testIds.dataTable.search`       | `data-table-search`             |
+| `testIds.dialog.yesNoYesBtn`     | `yesno-dialog-yes-btn`          |
+
+## What gets an ID
+
+Instrumented:
+
+- interactive elements: buttons, text fields, text areas, selects,
+  autocompletes, checkboxes, radio groups, file inputs, date pickers;
+- structural anchors: dialogs, data tables + rows, navigation entries,
+  page title, list cards, the global snackbar and error dialog.
+
+Not instrumented:
+
+- purely decorative elements (icons, tooltips, spacers, dividers).
+
+## Reusable components
+
+Wrapper components such as `NameInput` or `DienststellenInput` carry a **fixed**
+`data-test`. This is intentional and safe: the same wrapper never appears twice
+on screen at the same time, because the dialogs and views that host them are
+mutually exclusive. A test therefore always addresses a unique element.
+
+## Adding a new element
+
+1. Add a constant to the appropriate area object in `src/testIds.ts`.
+2. Bind it in the template via `:data-test="testIds.<area>.<name>"`.
+3. For inputs, remember tests select the inner control via
+   `[data-test='...'] input`.

--- a/praktikumsplaner-frontend/src/App.vue
+++ b/praktikumsplaner-frontend/src/App.vue
@@ -8,8 +8,14 @@
           cols="3"
           class="d-flex align-center justify-start"
         >
-          <v-app-bar-nav-icon @click.stop="toggleDrawer" />
-          <router-link to="/">
+          <v-app-bar-nav-icon
+            :data-test="testIds.app.navToggle"
+            @click.stop="toggleDrawer"
+          />
+          <router-link
+            to="/"
+            :data-test="testIds.app.homeLogo"
+          >
             <img
               height="50"
               width="50"
@@ -21,6 +27,7 @@
           <router-link
             to="/"
             class="text-decoration-none"
+            :data-test="testIds.app.homeTitle"
           >
             <v-toolbar-title class="font-weight-bold">
               <span class="text-white">Praktikumsplaner</span>
@@ -44,24 +51,28 @@
         <v-list-item
           v-if="security.isAusbildungsleitung()"
           :to="{ path: '/nachwuchskraefte' }"
+          :data-test="testIds.nav.nachwuchskraefte"
         >
           <v-list-item-title>Nachwuchskräfte</v-list-item-title>
         </v-list-item>
         <v-list-item
           v-if="security.isAusbildungsleitung()"
           :to="{ path: '/meldezeitraum' }"
+          :data-test="testIds.nav.meldezeitraum"
         >
           <v-list-item-title>Meldezeitraum</v-list-item-title>
         </v-list-item>
         <v-list-item
           v-if="security.checkForAnyRole(['AUSBILDER', 'AUSBILDUNGSLEITUNG'])"
           :to="{ path: '/praktikumsplaetze' }"
+          :data-test="testIds.nav.praktikumsplaetze"
         >
           <v-list-item-title>Praktikumsplätze</v-list-item-title>
         </v-list-item>
         <v-list-item
           v-if="security.isAusbildungsleitung()"
           :to="{ path: '/zuweisung' }"
+          :data-test="testIds.nav.zuweisung"
         >
           <v-list-item-title>Zuweisung</v-list-item-title>
         </v-list-item>
@@ -87,6 +98,7 @@ import ErrorDialog from "@/components/TheUserErrorDialog.vue";
 import { useSecurity } from "@/composables/security";
 import { useSnackbarStore } from "@/stores/snackbar";
 import { useUserStore } from "@/stores/user";
+import { testIds } from "@/testIds";
 
 const drawer = ref(true);
 const userStore = useUserStore();

--- a/praktikumsplaner-frontend/src/components/TheSnackbar.vue
+++ b/praktikumsplaner-frontend/src/components/TheSnackbar.vue
@@ -4,6 +4,7 @@
     v-model="show"
     :color="backgroundColor"
     :timeout="timeout"
+    :data-test="testIds.feedback.snackbar"
   >
     <v-row class="snackbarContent">
       <v-col class="message"> {{ message }}</v-col>
@@ -12,6 +13,7 @@
           v-if="backgroundColor !== 'success'"
           :color="btnTextColor"
           variant="text"
+          :data-test="testIds.feedback.snackbarCloseBtn"
           @click="show = false"
         >
           Schließen
@@ -25,6 +27,7 @@
 import { computed, ref, watch } from "vue";
 
 import { useSnackbarStore } from "@/stores/snackbar";
+import { testIds } from "@/testIds";
 
 const snackbarStore = useSnackbarStore();
 

--- a/praktikumsplaner-frontend/src/components/TheUserErrorDialog.vue
+++ b/praktikumsplaner-frontend/src/components/TheUserErrorDialog.vue
@@ -4,6 +4,7 @@
     :model-value="show"
     persistent
     width="800"
+    :data-test="testIds.feedback.errorDialog"
   >
     <v-card>
       <v-card-title>
@@ -18,6 +19,7 @@
         <v-spacer />
         <v-btn
           color="primary"
+          :data-test="testIds.feedback.errorDialogCloseBtn"
           @click="close"
         >
           Schließen
@@ -31,6 +33,7 @@
 import { computed } from "vue";
 
 import { useUserErrorStore } from "@/stores/user-error";
+import { testIds } from "@/testIds";
 
 const show = computed(() => errorStore.visible);
 const message = computed(() => errorStore.message ?? "");

--- a/praktikumsplaner-frontend/src/components/assign/ActiveNwkListForZuweisung.vue
+++ b/praktikumsplaner-frontend/src/components/assign/ActiveNwkListForZuweisung.vue
@@ -3,6 +3,7 @@
     v-if="properties.modelValue && properties.modelValue.length > 0"
     v-model:selected="selectedNwks"
     class="pr-2"
+    :data-test="testIds.assign.nwkList"
   >
     <v-list-item
       v-for="nwk in properties.modelValue"
@@ -39,6 +40,7 @@ import { onMounted, onUnmounted, ref } from "vue";
 
 import NwkCard from "@/components/assign/NwkCard.vue";
 import emitter from "@/stores/eventBus";
+import { testIds } from "@/testIds";
 import Nwk from "@/types/Nwk";
 
 const properties = defineProps<{

--- a/praktikumsplaner-frontend/src/components/assign/ExcelExport.vue
+++ b/praktikumsplaner-frontend/src/components/assign/ExcelExport.vue
@@ -3,6 +3,7 @@
     <v-btn
       color="primary"
       :prepend-icon="mdiTrayArrowDown"
+      :data-test="testIds.assign.exportBtn"
       @click="clickExport"
     >
       Exportieren
@@ -17,6 +18,7 @@ import { ref, watch } from "vue";
 
 import ExportService from "@/api/ExportService";
 import ProgressCircularOverlay from "@/components/common/ProgressCircularOverlay.vue";
+import { testIds } from "@/testIds";
 
 const loading = ref<boolean>(false);
 const properties = defineProps<{

--- a/praktikumsplaner-frontend/src/components/assign/NwkCard.vue
+++ b/praktikumsplaner-frontend/src/components/assign/NwkCard.vue
@@ -2,6 +2,7 @@
   <v-card
     width="100%"
     border
+    :data-test="testIds.assign.nwkCard"
   >
     <v-expansion-panels>
       <v-expansion-panel>
@@ -55,6 +56,7 @@
 import { computed } from "vue";
 
 import InitialsAvatar from "@/components/common/InitialsAvatar.vue";
+import { testIds } from "@/testIds";
 import { findBildungsrichtungColorByValue } from "@/types/Bildungsrichtung";
 import GermanWeekdayMapper from "@/types/GermanWeekdayMapper";
 import Nwk, { hasDetails } from "@/types/Nwk";

--- a/praktikumsplaner-frontend/src/components/assign/PraktikumsstelleCardZuweisung.vue
+++ b/praktikumsplaner-frontend/src/components/assign/PraktikumsstelleCardZuweisung.vue
@@ -2,6 +2,7 @@
   <v-card
     width="100%"
     border
+    :data-test="testIds.assign.praktikumsstelleCard"
     @click="show = !show"
     @drop="drop($event, praktikumsstelle)"
     @dragover.prevent
@@ -91,6 +92,7 @@ import YesNoDialogWithoutActivator from "@/components/common/YesNoDialogWithoutA
 import { useTextGenerator } from "@/composables/textGenerator";
 import { useWarnings } from "@/composables/warningGenerator";
 import emitter from "@/stores/eventBus";
+import { testIds } from "@/testIds";
 import { findBildungsrichtungColorByValue } from "@/types/Bildungsrichtung";
 import Nwk from "@/types/Nwk";
 import Praktikumsstelle from "@/types/Praktikumsstelle";

--- a/praktikumsplaner-frontend/src/components/assign/PraktikumsstellenListZuweisung.vue
+++ b/praktikumsplaner-frontend/src/components/assign/PraktikumsstellenListZuweisung.vue
@@ -2,6 +2,7 @@
   <v-list
     v-if="praktikumsstellen && praktikumsstellen.length > 0"
     class="pl-2"
+    :data-test="testIds.assign.praktikumsstellenList"
   >
     <v-list-item
       v-for="praktikumsstelle in praktikumsstellen"
@@ -43,6 +44,7 @@
 import { mdiInformationOutline } from "@mdi/js";
 
 import PraktikumsstelleCard from "@/components/assign/PraktikumsstelleCardZuweisung.vue";
+import { testIds } from "@/testIds";
 import Praktikumsstelle from "@/types/Praktikumsstelle";
 
 defineProps<{

--- a/praktikumsplaner-frontend/src/components/assign/UndeliveredMailsDialog.vue
+++ b/praktikumsplaner-frontend/src/components/assign/UndeliveredMailsDialog.vue
@@ -3,6 +3,7 @@
     :model-value="properties.showUndeliveredMailsDialog"
     persistent
     max-width="850px"
+    :data-test="testIds.assign.undeliveredMailsDialog"
   >
     <v-card>
       <v-card-title>
@@ -27,6 +28,7 @@
           <v-col class="col-auto mr-auto">
             <v-btn
               color="primary"
+              :data-test="testIds.assign.undeliveredMailsCloseBtn"
               @click="closeDialog"
             >
               Schließen
@@ -38,6 +40,7 @@
   </v-dialog>
 </template>
 <script setup lang="ts">
+import { testIds } from "@/testIds";
 import Praktikumsstelle from "@/types/Praktikumsstelle";
 
 const properties = defineProps<{

--- a/praktikumsplaner-frontend/src/components/common/BildungsrichtungSelect.vue
+++ b/praktikumsplaner-frontend/src/components/common/BildungsrichtungSelect.vue
@@ -6,12 +6,14 @@
     item-title="name"
     variant="outlined"
     clearable
+    :data-test="testIds.nwk.richtungSelect"
   ></v-autocomplete>
 </template>
 
 <script setup lang="ts">
 import { computed } from "vue";
 
+import { testIds } from "@/testIds";
 import {
   Ausbildungsrichtungen,
   BildungsrichtungKey,

--- a/praktikumsplaner-frontend/src/components/common/DataTable.vue
+++ b/praktikumsplaner-frontend/src/components/common/DataTable.vue
@@ -16,6 +16,7 @@
     items-per-page="-1"
     :show-expand="showExpand"
     :expand-on-click="expandOnClick"
+    :data-test="testIds.common.dataTable"
   >
     <template #[`item.actions`]="slotProps">
       <v-btn-group
@@ -44,6 +45,7 @@ import type SortItem from "@/types/DataTableSortItem";
 import { computed, ref } from "vue";
 
 import DataTableToolbar from "@/components/common/DataTableToolbar.vue";
+import { testIds } from "@/testIds";
 
 withDefaults(
   defineProps<{

--- a/praktikumsplaner-frontend/src/components/common/DataTableToolbar.vue
+++ b/praktikumsplaner-frontend/src/components/common/DataTableToolbar.vue
@@ -8,6 +8,7 @@
         label="Suche"
         hide-details
         clearable
+        :data-test="testIds.common.dataTableSearch"
       />
     </v-col>
     <v-col
@@ -22,6 +23,7 @@
         hide-details
         clearable
         :items="groupByOptions"
+        :data-test="testIds.common.dataTableGroupBy"
       />
     </v-col>
     <v-col></v-col>
@@ -30,6 +32,8 @@
 
 <script setup lang="ts">
 import type GroupOption from "@/types/DataTableGroupOption";
+
+import { testIds } from "@/testIds";
 
 defineProps<{
   groupByOptions?: GroupOption[];

--- a/praktikumsplaner-frontend/src/components/common/DatePicker.vue
+++ b/praktikumsplaner-frontend/src/components/common/DatePicker.vue
@@ -8,6 +8,7 @@
         :model-value="formatDate(properties.value)"
         :rules="properties.rules"
         v-bind="props"
+        :data-test="testIds.common.datePickerField"
       ></v-text-field>
     </template>
     <v-date-picker
@@ -19,6 +20,8 @@
 
 <script setup lang="ts">
 import { computed, ref } from "vue";
+
+import { testIds } from "@/testIds";
 
 const properties = defineProps<{
   prependIcon: string;

--- a/praktikumsplaner-frontend/src/components/common/JahrgangInput.vue
+++ b/praktikumsplaner-frontend/src/components/common/JahrgangInput.vue
@@ -4,12 +4,14 @@
     label="Jahrgang"
     :rules="jahrgangRule"
     variant="outlined"
+    :data-test="testIds.nwk.jahrgangInput"
   ></v-text-field>
 </template>
 <script setup lang="ts">
 import { computed } from "vue";
 
 import { useRules } from "@/composables/rules";
+import { testIds } from "@/testIds";
 import NwkCreate from "@/types/NwkCreate";
 
 const validationRules = useRules();

--- a/praktikumsplaner-frontend/src/components/common/NameInput.vue
+++ b/praktikumsplaner-frontend/src/components/common/NameInput.vue
@@ -6,6 +6,7 @@
         label="Vorname"
         :rules="nameRule"
         variant="outlined"
+        :data-test="testIds.nwk.vornameInput"
       ></v-text-field>
     </v-col>
     <v-col cols="6">
@@ -14,6 +15,7 @@
         label="Nachname"
         :rules="nameRule"
         variant="outlined"
+        :data-test="testIds.nwk.nachnameInput"
       ></v-text-field>
     </v-col>
   </v-row>
@@ -22,6 +24,7 @@
 import { computed } from "vue";
 
 import { useRules } from "@/composables/rules";
+import { testIds } from "@/testIds";
 import NwkCreate from "@/types/NwkCreate";
 
 const validationRules = useRules();

--- a/praktikumsplaner-frontend/src/components/common/PageTitle.vue
+++ b/praktikumsplaner-frontend/src/components/common/PageTitle.vue
@@ -10,9 +10,12 @@
         :icon="mdiArrowLeft"
         elevation="0"
         class="mr-2"
+        :data-test="testIds.common.pageTitleBackBtn"
       >
       </v-btn>
-      <h1>{{ properties.pageHeaderText }}</h1>
+      <h1 :data-test="testIds.common.pageTitle">
+        {{ properties.pageHeaderText }}
+      </h1>
     </v-col>
     <v-col class="d-flex justify-end align-center">
       <v-btn-group>
@@ -24,6 +27,8 @@
 
 <script setup lang="ts">
 import { mdiArrowLeft } from "@mdi/js";
+
+import { testIds } from "@/testIds";
 
 const properties = defineProps<{
   pageHeaderText: string;

--- a/praktikumsplaner-frontend/src/components/common/TwoChoiceDialogCards.vue
+++ b/praktikumsplaner-frontend/src/components/common/TwoChoiceDialogCards.vue
@@ -11,6 +11,7 @@
           color="primary"
           :prepend-icon="properties.icon"
           v-bind="props"
+          :data-test="testIds.dialog.twoChoiceActivatorBtn"
         >
           {{ buttontext }}
         </v-btn>
@@ -19,6 +20,7 @@
         <v-btn
           color="primary"
           v-bind="props"
+          :data-test="testIds.dialog.twoChoiceActivatorBtn"
         >
           {{ buttontext }}
         </v-btn>
@@ -40,6 +42,7 @@
               max-width="300"
               variant="outlined"
               rounded
+              :data-test="testIds.dialog.twoChoiceOne"
               @click="choiceOne"
             >
               <v-card-title class="mt-1">
@@ -56,6 +59,7 @@
               max-width="300"
               variant="outlined"
               rounded
+              :data-test="testIds.dialog.twoChoiceTwo"
               @click="choiceTwo"
             >
               <v-card-title class="mt-1">
@@ -74,6 +78,7 @@
         <v-btn
           variant="text"
           color="primary"
+          :data-test="testIds.dialog.twoChoiceCloseBtn"
           @click="close"
         >
           Schließen
@@ -85,6 +90,8 @@
 
 <script setup lang="ts">
 import { computed } from "vue";
+
+import { testIds } from "@/testIds";
 
 const properties = defineProps<{
   buttontext: string;

--- a/praktikumsplaner-frontend/src/components/common/WarningDialog.vue
+++ b/praktikumsplaner-frontend/src/components/common/WarningDialog.vue
@@ -13,12 +13,14 @@
         <v-btn
           color="primary"
           variant="elevated"
+          :data-test="testIds.dialog.warningAcceptBtn"
           @click="accept"
           >Akzeptieren
         </v-btn>
         <v-btn
           color="error"
           variant="elevated"
+          :data-test="testIds.dialog.warningRejectBtn"
           @click="reject"
           >Ablehnen
         </v-btn>
@@ -30,6 +32,7 @@
 <script setup lang="ts">
 import { computed, ref } from "vue";
 
+import { testIds } from "@/testIds";
 import Warning from "@/types/Warning";
 
 const emits = defineEmits<(e: "accepted" | "rejected") => void>();

--- a/praktikumsplaner-frontend/src/components/common/YesNoDialog.vue
+++ b/praktikumsplaner-frontend/src/components/common/YesNoDialog.vue
@@ -9,6 +9,7 @@
         <v-btn
           color="primary"
           v-bind="open"
+          :data-test="testIds.dialog.yesNoActivatorBtn"
         >
           {{ buttontext }}
         </v-btn>
@@ -17,6 +18,7 @@
         <v-btn
           color="primary"
           v-bind="open"
+          :data-test="testIds.dialog.yesNoActivatorBtn"
         >
           <v-icon size="large">
             {{ icontext }}
@@ -35,6 +37,7 @@
         <v-spacer />
         <v-btn
           id="yesnodialog-btn-no"
+          :data-test="testIds.dialog.yesNoNoBtn"
           variant="outlined"
           @click="no"
         >
@@ -42,6 +45,7 @@
         </v-btn>
         <v-btn
           id="yesnodialog-btn-yes"
+          :data-test="testIds.dialog.yesNoYesBtn"
           color="primary"
           variant="elevated"
           @click="yes"
@@ -55,6 +59,8 @@
 
 <script setup lang="ts">
 import { computed } from "vue";
+
+import { testIds } from "@/testIds";
 
 /**
  * Der YesNo-Dialog ist ein generischer Dialog zur binären Abfrage beim Nutzer.

--- a/praktikumsplaner-frontend/src/components/common/YesNoDialogWithoutActivator.vue
+++ b/praktikumsplaner-frontend/src/components/common/YesNoDialogWithoutActivator.vue
@@ -18,12 +18,14 @@
         <v-spacer />
         <v-btn
           id="yesnodialog-btn-no"
+          :data-test="testIds.dialog.yesNoNoBtn"
           variant="outlined"
           @click="no"
           >Nein
         </v-btn>
         <v-btn
           id="yesnodialog-btn-yes"
+          :data-test="testIds.dialog.yesNoYesBtn"
           variant="flat"
           color="primary"
           @click="yes"
@@ -36,6 +38,8 @@
 
 <script setup lang="ts">
 import { computed } from "vue";
+
+import { testIds } from "@/testIds";
 
 const properties = defineProps<{
   dialogtitle: string;

--- a/praktikumsplaner-frontend/src/components/meldezeitraeume/CreateMeldezeitraum.vue
+++ b/praktikumsplaner-frontend/src/components/meldezeitraeume/CreateMeldezeitraum.vue
@@ -3,12 +3,14 @@
     :prepend-icon="mdiPlus"
     color="primary"
     text="Hinzufügen"
+    :data-test="testIds.meldezeitraum.createOpenBtn"
     @click="visible = true"
   />
   <v-dialog
     v-model="visible"
     persistent
     width="600"
+    :data-test="testIds.meldezeitraum.createDialog"
   >
     <v-card>
       <v-card-title>Meldezeitraum Anlegen</v-card-title>
@@ -21,6 +23,7 @@
               :rules="zeitraumNameRules"
               variant="outlined"
               class="mb-3"
+              :data-test="testIds.meldezeitraum.nameInput"
             ></v-text-field>
             <zeitraum-picker
               :value="meldezeitraum.zeitraum"
@@ -34,6 +37,7 @@
           variant="outlined"
           color="primary"
           class="ml-7 mb-2"
+          :data-test="testIds.meldezeitraum.backBtn"
           @click="close"
         >
           Zurück
@@ -43,6 +47,7 @@
           color="primary"
           variant="elevated"
           class="mr-7 mb-2"
+          :data-test="testIds.meldezeitraum.saveBtn"
           @click="clickSpeichern"
         >
           Speichern
@@ -61,6 +66,7 @@ import MeldezeitraumService from "@/api/MeldezeitraumService";
 import ProgressCircularOverlay from "@/components/common/ProgressCircularOverlay.vue";
 import ZeitraumPicker from "@/components/meldezeitraeume/ZeitraumPicker.vue";
 import { useRules } from "@/composables/rules";
+import { testIds } from "@/testIds";
 import Meldezeitraum from "@/types/Meldezeitraum";
 import Zeitraum from "@/types/Zeitraum";
 

--- a/praktikumsplaner-frontend/src/components/meldezeitraeume/MeldezeitraumList.vue
+++ b/praktikumsplaner-frontend/src/components/meldezeitraeume/MeldezeitraumList.vue
@@ -7,6 +7,7 @@
       border
       elevation="0"
       class="mt-1"
+      :data-test="testIds.meldezeitraum.listCard"
     >
       <v-list-item lines="two">
         <v-list-item-title class="justify-center">
@@ -32,6 +33,7 @@
             <v-btn
               color="error"
               :icon="mdiDelete"
+              :data-test="testIds.meldezeitraum.deleteBtn"
               @click="warnBeforeDelete(meldezeitraum)"
             >
             </v-btn>
@@ -62,6 +64,7 @@ import MeldezeitraumService from "@/api/MeldezeitraumService";
 import ProgressCircularOverlay from "@/components/common/ProgressCircularOverlay.vue";
 import YesNoDialogWithoutActivator from "@/components/common/YesNoDialogWithoutActivator.vue";
 import { useFormatter } from "@/composables/formatter";
+import { testIds } from "@/testIds";
 import Meldezeitraum from "@/types/Meldezeitraum";
 
 const showDeleteWarningDialog = ref(false);

--- a/praktikumsplaner-frontend/src/components/meldezeitraeume/ZeitraumPicker.vue
+++ b/praktikumsplaner-frontend/src/components/meldezeitraeume/ZeitraumPicker.vue
@@ -11,6 +11,7 @@
             type="date"
             :label="'Beginn des ' + properties.label + 's'"
             :rules="startZeitpunktRules"
+            :data-test="testIds.meldezeitraum.startInput"
           >
           </v-text-field>
         </v-col>
@@ -23,6 +24,7 @@
             type="date"
             :label="'Ende des ' + properties.label + 's'"
             :rules="endZeitpunktRules"
+            :data-test="testIds.meldezeitraum.endInput"
           >
           </v-text-field>
         </v-col>
@@ -35,6 +37,7 @@
 import { computed, ref } from "vue";
 
 import { useRules } from "@/composables/rules";
+import { testIds } from "@/testIds";
 import Zeitraum from "@/types/Zeitraum";
 
 const properties = defineProps<{

--- a/praktikumsplaner-frontend/src/components/nachwuchskraefte/ExcelImportNwk.vue
+++ b/praktikumsplaner-frontend/src/components/nachwuchskraefte/ExcelImportNwk.vue
@@ -2,6 +2,7 @@
   <v-btn
     :prepend-icon="mdiTrayArrowUp"
     color="primary"
+    :data-test="testIds.nwk.excelImportOpenBtn"
     @click="visible = true"
   >
     Datei Hochladen
@@ -10,6 +11,7 @@
     v-model="visible"
     persistent
     max-width="550"
+    :data-test="testIds.nwk.excelImportDialog"
   >
     <v-form ref="form">
       <v-card>
@@ -23,6 +25,7 @@
             :rules="rules"
             label="Datei auswählen"
             :prepend-icon="mdiTrayArrowUp"
+            :data-test="testIds.nwk.excelImportFileInput"
           ></v-file-input>
         </v-card-text>
         <v-card-actions>
@@ -30,6 +33,7 @@
           <v-btn
             color="primary"
             variant="outlined"
+            :data-test="testIds.nwk.excelImportCancelBtn"
             @click="cancel()"
           >
             Abbrechen
@@ -37,6 +41,7 @@
           <v-btn
             color="primary"
             variant="flat"
+            :data-test="testIds.nwk.excelImportUploadBtn"
             @click="uploadFile()"
           >
             Hochladen
@@ -56,6 +61,7 @@ import NwkService from "@/api/NwkService";
 import ProgressCircularOverlay from "@/components/common/ProgressCircularOverlay.vue";
 import { useRules } from "@/composables/rules";
 import emitter from "@/stores/eventBus";
+import { testIds } from "@/testIds";
 
 const visible = ref<boolean>(false);
 const loading = ref<boolean>(false);

--- a/praktikumsplaner-frontend/src/components/nachwuchskraefte/NwkCreateDialog.vue
+++ b/praktikumsplaner-frontend/src/components/nachwuchskraefte/NwkCreateDialog.vue
@@ -3,12 +3,14 @@
     :prepend-icon="mdiPlus"
     color="primary"
     text="Hinzufügen"
+    :data-test="testIds.nwk.createDialogOpenBtn"
     @click="visible = true"
   />
   <v-dialog
     v-model="visible"
     persistent
     max-width="550"
+    :data-test="testIds.nwk.createDialog"
   >
     <v-form ref="form">
       <v-card>
@@ -49,6 +51,7 @@
           <v-btn
             color="primary"
             variant="outlined"
+            :data-test="testIds.nwk.cancelBtn"
             @click="cancel()"
           >
             Abbrechen
@@ -56,6 +59,7 @@
           <v-btn
             color="primary"
             variant="flat"
+            :data-test="testIds.nwk.acceptBtn"
             @click="saveNwk()"
           >
             Akzeptieren
@@ -78,6 +82,7 @@ import NameInput from "@/components/common/NameInput.vue";
 import ProgressCircularOverlay from "@/components/common/ProgressCircularOverlay.vue";
 import VorlesungstageSelector from "@/components/nachwuchskraefte/VorlesungstageSelect.vue";
 import emitter from "@/stores/eventBus";
+import { testIds } from "@/testIds";
 import NwkCreate from "@/types/NwkCreate";
 
 const visible = ref<boolean>(false);

--- a/praktikumsplaner-frontend/src/components/nachwuchskraefte/NwkUpdateDialog.vue
+++ b/praktikumsplaner-frontend/src/components/nachwuchskraefte/NwkUpdateDialog.vue
@@ -3,12 +3,14 @@
     :icon="mdiPencilOutline"
     color="primary"
     aria-label="Bearbeiten"
+    :data-test="testIds.nwk.updateDialogOpenBtn"
     @click="visible = true"
   ></v-btn>
   <v-dialog
     v-model="visible"
     persistent
     max-width="550"
+    :data-test="testIds.nwk.updateDialog"
   >
     <v-form ref="form">
       <v-card>
@@ -48,6 +50,7 @@
           <v-btn
             color="primary"
             variant="outlined"
+            :data-test="testIds.nwk.cancelBtn"
             @click="cancel()"
           >
             Abbrechen
@@ -55,6 +58,7 @@
           <v-btn
             color="primary"
             variant="flat"
+            :data-test="testIds.nwk.acceptBtn"
             @click="updateNwk()"
           >
             Akzeptieren
@@ -76,6 +80,7 @@ import JahrgangInput from "@/components/common/JahrgangInput.vue";
 import NameInput from "@/components/common/NameInput.vue";
 import ProgressCircularOverlay from "@/components/common/ProgressCircularOverlay.vue";
 import VorlesungstageSelector from "@/components/nachwuchskraefte/VorlesungstageSelect.vue";
+import { testIds } from "@/testIds";
 import Nwk from "@/types/Nwk";
 
 const visible = ref<boolean>(false);

--- a/praktikumsplaner-frontend/src/components/nachwuchskraefte/VorlesungstageSelect.vue
+++ b/praktikumsplaner-frontend/src/components/nachwuchskraefte/VorlesungstageSelect.vue
@@ -8,6 +8,7 @@
     item-title="germanWeekDay"
     variant="outlined"
     multiple
+    :data-test="testIds.nwk.vorlesungstageSelect"
   >
   </v-select>
 </template>
@@ -15,6 +16,7 @@
 <script setup lang="ts">
 import { computed, ref } from "vue";
 
+import { testIds } from "@/testIds";
 import Day from "@/types/Day";
 import GermanWeekdayMapper from "@/types/GermanWeekdayMapper";
 import NwkCreate from "@/types/NwkCreate";

--- a/praktikumsplaner-frontend/src/components/praktikumsplaetze/Meldung/AusbilderEmailInput.vue
+++ b/praktikumsplaner-frontend/src/components/praktikumsplaetze/Meldung/AusbilderEmailInput.vue
@@ -6,6 +6,7 @@
     variant="outlined"
     :clearable="!isRequired"
     :disabled="disabled"
+    :data-test="testIds.praktikumsstelle.ausbilderEmailInput"
   ></v-text-field>
 </template>
 
@@ -13,6 +14,7 @@
 import { computed } from "vue";
 
 import { useRules } from "@/composables/rules";
+import { testIds } from "@/testIds";
 import Praktikumsstelle from "@/types/Praktikumsstelle";
 
 const validationRules = useRules();

--- a/praktikumsplaner-frontend/src/components/praktikumsplaetze/Meldung/AusbilderErwFuehrungszeugnisCheckbox.vue
+++ b/praktikumsplaner-frontend/src/components/praktikumsplaetze/Meldung/AusbilderErwFuehrungszeugnisCheckbox.vue
@@ -3,12 +3,14 @@
     v-model="stelle.erwFuehrungszeugnisVorhanden"
     :label="label"
     :disabled="disabled"
+    :data-test="testIds.praktikumsstelle.fuehrungszeugnisCheckbox"
   ></v-checkbox>
 </template>
 
 <script setup lang="ts">
 import { computed } from "vue";
 
+import { testIds } from "@/testIds";
 import Praktikumsstelle from "@/types/Praktikumsstelle";
 
 interface Properties {

--- a/praktikumsplaner-frontend/src/components/praktikumsplaetze/Meldung/AusbilderInput.vue
+++ b/praktikumsplaner-frontend/src/components/praktikumsplaetze/Meldung/AusbilderInput.vue
@@ -6,6 +6,7 @@
     variant="outlined"
     :clearable="!isRequired"
     :disabled="disabled"
+    :data-test="testIds.praktikumsstelle.ausbilderInput"
   ></v-text-field>
 </template>
 
@@ -13,6 +14,7 @@
 import { computed } from "vue";
 
 import { useRules } from "@/composables/rules";
+import { testIds } from "@/testIds";
 import Praktikumsstelle from "@/types/Praktikumsstelle";
 
 const validationRules = useRules();

--- a/praktikumsplaner-frontend/src/components/praktikumsplaetze/Meldung/AusbildungsJahrSelect.vue
+++ b/praktikumsplaner-frontend/src/components/praktikumsplaetze/Meldung/AusbildungsJahrSelect.vue
@@ -10,6 +10,7 @@
     :rules="conditionalRequiredRules"
     :clearable="!isRequired"
     :disabled="disabled"
+    :data-test="testIds.praktikumsstelle.ausbildungsjahrSelect"
     @update:model-value="sortAusbildungsjahre"
   >
     <template #prepend-item>
@@ -59,6 +60,7 @@
 import { computed } from "vue";
 
 import { useRules } from "@/composables/rules";
+import { testIds } from "@/testIds";
 import { Ausbildungsjahr } from "@/types/Ausbildungsjahr";
 import Praktikumsstelle from "@/types/Praktikumsstelle";
 

--- a/praktikumsplaner-frontend/src/components/praktikumsplaetze/Meldung/AusbildungsrichtungSelect.vue
+++ b/praktikumsplaner-frontend/src/components/praktikumsplaetze/Meldung/AusbildungsrichtungSelect.vue
@@ -9,6 +9,7 @@
     variant="outlined"
     :clearable="!isRequired"
     :disabled="disabled"
+    :data-test="testIds.praktikumsstelle.ausbildungsrichtungSelect"
   >
   </v-select>
 </template>
@@ -17,6 +18,7 @@
 import { computed } from "vue";
 
 import { useRules } from "@/composables/rules";
+import { testIds } from "@/testIds";
 import { Ausbildungsrichtung } from "@/types/Ausbildungsrichtung";
 import Praktikumsstelle from "@/types/Praktikumsstelle";
 

--- a/praktikumsplaner-frontend/src/components/praktikumsplaetze/Meldung/DienststellenInput.vue
+++ b/praktikumsplaner-frontend/src/components/praktikumsplaetze/Meldung/DienststellenInput.vue
@@ -8,6 +8,7 @@
     :rules="conditionalRequiredRules"
     variant="outlined"
     :clearable="!isRequired"
+    :data-test="testIds.praktikumsstelle.dienststelleInput"
   ></v-text-field>
 </template>
 
@@ -17,6 +18,7 @@ import { computed } from "vue";
 import { useRules } from "@/composables/rules";
 import { useSecurity } from "@/composables/security";
 import { useUserStore } from "@/stores/user";
+import { testIds } from "@/testIds";
 import Praktikumsstelle from "@/types/Praktikumsstelle";
 
 const validationRules = useRules();

--- a/praktikumsplaner-frontend/src/components/praktikumsplaetze/Meldung/DringlichkeitSelect.vue
+++ b/praktikumsplaner-frontend/src/components/praktikumsplaetze/Meldung/DringlichkeitSelect.vue
@@ -9,6 +9,7 @@
     :rules="conditionalRequiredRules"
     variant="outlined"
     :clearable="!isRequired"
+    :data-test="testIds.praktikumsstelle.dringlichkeitSelect"
   ></v-select>
 </template>
 
@@ -16,6 +17,7 @@
 import { computed } from "vue";
 
 import { useRules } from "@/composables/rules";
+import { testIds } from "@/testIds";
 import { Dringlichkeit } from "@/types/Dringlichkeit";
 import Praktikumsstelle from "@/types/Praktikumsstelle";
 

--- a/praktikumsplaner-frontend/src/components/praktikumsplaetze/Meldung/MeldezeitraumSelect.vue
+++ b/praktikumsplaner-frontend/src/components/praktikumsplaetze/Meldung/MeldezeitraumSelect.vue
@@ -9,6 +9,7 @@
     variant="outlined"
     :clearable="!isRequired"
     :disabled="disabled"
+    :data-test="testIds.praktikumsstelle.meldezeitraumSelect"
     @select="onClick"
   >
     <template #item="{ props, item }">
@@ -33,6 +34,7 @@ import { computed } from "vue";
 
 import { useFormatter } from "@/composables/formatter";
 import { useRules } from "@/composables/rules";
+import { testIds } from "@/testIds";
 import Meldezeitraum from "@/types/Meldezeitraum";
 import Praktikumsstelle from "@/types/Praktikumsstelle";
 

--- a/praktikumsplaner-frontend/src/components/praktikumsplaetze/Meldung/MinderjaehrigMoeglichRadioGroup.vue
+++ b/praktikumsplaner-frontend/src/components/praktikumsplaetze/Meldung/MinderjaehrigMoeglichRadioGroup.vue
@@ -5,6 +5,7 @@
     inline
     :rules="conditionalRequiredRules"
     :disabled="disabled"
+    :data-test="testIds.praktikumsstelle.minderjaehrigRadio"
   >
     <template #label>
       <span class="custom-label">{{ conditionalRequiredLabel }}:</span>
@@ -23,6 +24,7 @@
 import { computed } from "vue";
 
 import { useRules } from "@/composables/rules";
+import { testIds } from "@/testIds";
 import Praktikumsstelle from "@/types/Praktikumsstelle";
 import { YesNoBoolean } from "@/types/YesNoBoolean";
 

--- a/praktikumsplaner-frontend/src/components/praktikumsplaetze/Meldung/NamentlicheAnforderungInput.vue
+++ b/praktikumsplaner-frontend/src/components/praktikumsplaetze/Meldung/NamentlicheAnforderungInput.vue
@@ -6,6 +6,7 @@
     variant="outlined"
     :clearable="!isRequired"
     :disabled="disabled"
+    :data-test="testIds.praktikumsstelle.namentlicheAnforderungInput"
   ></v-text-field>
 </template>
 
@@ -13,6 +14,7 @@
 import { computed } from "vue";
 
 import { useRules } from "@/composables/rules";
+import { testIds } from "@/testIds";
 import Praktikumsstelle from "@/types/Praktikumsstelle";
 
 const validationRules = useRules();

--- a/praktikumsplaner-frontend/src/components/praktikumsplaetze/Meldung/PlanstelleRadioGroup.vue
+++ b/praktikumsplaner-frontend/src/components/praktikumsplaetze/Meldung/PlanstelleRadioGroup.vue
@@ -5,6 +5,7 @@
     inline
     :rules="conditionalRequiredRules"
     :disabled="disabled"
+    :data-test="testIds.praktikumsstelle.planstelleRadio"
   >
     <template #label>
       <span class="custom-label">{{ conditionalRequiredLabel }}:</span>
@@ -23,6 +24,7 @@
 import { computed } from "vue";
 
 import { useRules } from "@/composables/rules";
+import { testIds } from "@/testIds";
 import Praktikumsstelle from "@/types/Praktikumsstelle";
 import { YesNoBoolean } from "@/types/YesNoBoolean";
 

--- a/praktikumsplaner-frontend/src/components/praktikumsplaetze/Meldung/ProgrammierKenntnisseSelect.vue
+++ b/praktikumsplaner-frontend/src/components/praktikumsplaetze/Meldung/ProgrammierKenntnisseSelect.vue
@@ -9,6 +9,7 @@
     variant="outlined"
     :clearable="!isRequired"
     :disabled="disabled"
+    :data-test="testIds.praktikumsstelle.programmierkenntnisseSelect"
   >
   </v-select>
 </template>
@@ -17,6 +18,7 @@
 import { computed } from "vue";
 
 import { useRules } from "@/composables/rules";
+import { testIds } from "@/testIds";
 import Praktikumsstelle from "@/types/Praktikumsstelle";
 import { Programmierkenntnisse } from "@/types/YesNoEgalBoolean";
 

--- a/praktikumsplaner-frontend/src/components/praktikumsplaetze/Meldung/ProjektarbeitRadioGroup.vue
+++ b/praktikumsplaner-frontend/src/components/praktikumsplaetze/Meldung/ProjektarbeitRadioGroup.vue
@@ -5,6 +5,7 @@
     inline
     :rules="conditionalRequiredRules"
     :disabled="disabled"
+    :data-test="testIds.praktikumsstelle.projektarbeitRadio"
   >
     <template #label>
       <span class="custom-label">{{ conditionalRequiredLabel }}:</span>
@@ -23,6 +24,7 @@
 import { computed } from "vue";
 
 import { useRules } from "@/composables/rules";
+import { testIds } from "@/testIds";
 import Praktikumsstelle from "@/types/Praktikumsstelle";
 import { YesNoBoolean } from "@/types/YesNoBoolean";
 

--- a/praktikumsplaner-frontend/src/components/praktikumsplaetze/Meldung/StudienrichtungSelect.vue
+++ b/praktikumsplaner-frontend/src/components/praktikumsplaetze/Meldung/StudienrichtungSelect.vue
@@ -9,6 +9,7 @@
     variant="outlined"
     :clearable="!isRequired"
     :disabled="disabled"
+    :data-test="testIds.praktikumsstelle.studienrichtungSelect"
   >
   </v-select>
 </template>
@@ -17,6 +18,7 @@
 import { computed } from "vue";
 
 import { useRules } from "@/composables/rules";
+import { testIds } from "@/testIds";
 import Praktikumsstelle from "@/types/Praktikumsstelle";
 import { Studiengang } from "@/types/Studiengang";
 

--- a/praktikumsplaner-frontend/src/components/praktikumsplaetze/Meldung/StudiensemesterSelect.vue
+++ b/praktikumsplaner-frontend/src/components/praktikumsplaetze/Meldung/StudiensemesterSelect.vue
@@ -10,6 +10,7 @@
     :rules="conditionalRequiredRules"
     :clearable="!isRequired"
     :disabled="disabled"
+    :data-test="testIds.praktikumsstelle.studiensemesterSelect"
     @update:model-value="sortSemester"
   >
     <template #prepend-item>
@@ -63,6 +64,7 @@
 import { computed } from "vue";
 
 import { useRules } from "@/composables/rules";
+import { testIds } from "@/testIds";
 import Praktikumsstelle from "@/types/Praktikumsstelle";
 import { Studiensemester } from "@/types/Studiensemester";
 

--- a/praktikumsplaner-frontend/src/components/praktikumsplaetze/Meldung/TaetigkeitenInput.vue
+++ b/praktikumsplaner-frontend/src/components/praktikumsplaetze/Meldung/TaetigkeitenInput.vue
@@ -6,6 +6,7 @@
     variant="outlined"
     :clearable="!isRequired"
     :disabled="disabled"
+    :data-test="testIds.praktikumsstelle.taetigkeitenInput"
   ></v-textarea>
 </template>
 
@@ -13,6 +14,7 @@
 import { computed } from "vue";
 
 import { useRules } from "@/composables/rules";
+import { testIds } from "@/testIds";
 import Praktikumsstelle from "@/types/Praktikumsstelle";
 
 const validationRules = useRules();

--- a/praktikumsplaner-frontend/src/components/praktikumsplaetze/Meldung/WuenscheInput.vue
+++ b/praktikumsplaner-frontend/src/components/praktikumsplaetze/Meldung/WuenscheInput.vue
@@ -6,6 +6,7 @@
     variant="outlined"
     :clearable="!isRequired"
     :disabled="disabled"
+    :data-test="testIds.praktikumsstelle.wuenscheInput"
   ></v-textarea>
 </template>
 
@@ -13,6 +14,7 @@
 import { computed } from "vue";
 
 import { useRules } from "@/composables/rules";
+import { testIds } from "@/testIds";
 import Praktikumsstelle from "@/types/Praktikumsstelle";
 
 const validationRules = useRules();

--- a/praktikumsplaner-frontend/src/components/praktikumsplaetze/Praktikumsplaetze/AusbildungsPraktikumsstelleUpdateDialog.vue
+++ b/praktikumsplaner-frontend/src/components/praktikumsplaetze/Praktikumsplaetze/AusbildungsPraktikumsstelleUpdateDialog.vue
@@ -4,6 +4,7 @@
     :prepend-icon="mdiPencilOutline"
     color="primary"
     variant="outlined"
+    :data-test="testIds.praktikumsstelle.editBtn"
     @click.stop="openDialog()"
   >
     Bearbeiten
@@ -13,6 +14,7 @@
     :icon="mdiPencil"
     color="primary"
     aria-label="Bearbeiten"
+    :data-test="testIds.praktikumsstelle.editBtn"
     @click.stop="openDialog()"
   >
   </v-btn>
@@ -20,6 +22,7 @@
     v-model="visible"
     persistent
     max-width="1000"
+    :data-test="testIds.praktikumsstelle.editDialog"
   >
     <v-form ref="form">
       <v-card>
@@ -235,6 +238,7 @@
           <v-btn
             color="primary"
             variant="outlined"
+            :data-test="testIds.praktikumsstelle.cancelBtn"
             @click="closeDialog()"
           >
             Abbrechen
@@ -244,6 +248,7 @@
             color="primary"
             variant="flat"
             :disabled="hasAssignedNwk"
+            :data-test="testIds.praktikumsstelle.acceptBtn"
             @click="updatePraktikumsstelle()"
           >
             Akzeptieren
@@ -283,6 +288,7 @@ import TaetigkeitenInput from "@/components/praktikumsplaetze/Meldung/Taetigkeit
 import WuenscheInput from "@/components/praktikumsplaetze/Meldung/WuenscheInput.vue";
 import WuenscheTooltip from "@/components/praktikumsplaetze/Meldung/WuenscheTooltip.vue";
 import emitter from "@/stores/eventBus";
+import { testIds } from "@/testIds";
 import Meldezeitraum from "@/types/Meldezeitraum";
 import Praktikumsstelle from "@/types/Praktikumsstelle";
 import Zeitraum from "@/types/Zeitraum";

--- a/praktikumsplaner-frontend/src/components/praktikumsplaetze/Praktikumsplaetze/PraktikumsstelleDeleteDialog.vue
+++ b/praktikumsplaner-frontend/src/components/praktikumsplaetze/Praktikumsplaetze/PraktikumsstelleDeleteDialog.vue
@@ -3,6 +3,7 @@
     :icon="mdiDelete"
     color="error"
     alt-text="Löschen"
+    :data-test="testIds.praktikumsstelle.deleteBtn"
     @click.stop="openDialog"
   />
   <yes-no-dialog-without-activator
@@ -24,6 +25,7 @@ import { ref } from "vue";
 import PraktikumsstellenService from "@/api/PraktikumsstellenService";
 import ProgressCircularOverlay from "@/components/common/ProgressCircularOverlay.vue";
 import YesNoDialogWithoutActivator from "@/components/common/YesNoDialogWithoutActivator.vue";
+import { testIds } from "@/testIds";
 
 const props = defineProps<{
   stelle: Praktikumsstelle;

--- a/praktikumsplaner-frontend/src/components/praktikumsplaetze/Praktikumsplaetze/StudiumsPraktikumsstelleUpdateDialog.vue
+++ b/praktikumsplaner-frontend/src/components/praktikumsplaetze/Praktikumsplaetze/StudiumsPraktikumsstelleUpdateDialog.vue
@@ -4,6 +4,7 @@
     :prepend-icon="mdiPencilOutline"
     color="primary"
     variant="outlined"
+    :data-test="testIds.praktikumsstelle.editBtn"
     @click.stop="openDialog()"
     >Bearbeiten
   </v-btn>
@@ -12,12 +13,14 @@
     :icon="mdiPencil"
     color="primary"
     aria-label="Bearbeiten"
+    :data-test="testIds.praktikumsstelle.editBtn"
     @click.stop="openDialog()"
   ></v-btn>
   <v-dialog
     v-model="visible"
     persistent
     max-width="1000"
+    :data-test="testIds.praktikumsstelle.editDialog"
   >
     <v-form ref="form">
       <v-card>
@@ -210,6 +213,7 @@
           <v-btn
             color="primary"
             variant="outlined"
+            :data-test="testIds.praktikumsstelle.cancelBtn"
             @click="closeDialog()"
           >
             Abbrechen
@@ -219,6 +223,7 @@
             color="primary"
             variant="flat"
             :disabled="hasAssignedNwk"
+            :data-test="testIds.praktikumsstelle.acceptBtn"
             @click="updatePraktikumsstelle()"
           >
             Akzeptieren
@@ -256,6 +261,7 @@ import TaetigkeitenInput from "@/components/praktikumsplaetze/Meldung/Taetigkeit
 import WuenscheInput from "@/components/praktikumsplaetze/Meldung/WuenscheInput.vue";
 import WuenscheTooltip from "@/components/praktikumsplaetze/Meldung/WuenscheTooltip.vue";
 import emitter from "@/stores/eventBus";
+import { testIds } from "@/testIds";
 import Meldezeitraum from "@/types/Meldezeitraum";
 import Zeitraum from "@/types/Zeitraum";
 

--- a/praktikumsplaner-frontend/src/testIds.ts
+++ b/praktikumsplaner-frontend/src/testIds.ts
@@ -1,0 +1,141 @@
+/**
+ * Central catalogue of `data-test` attribute values used to instrument the UI
+ * for automated end-to-end tests (e.g. Selenium).
+ *
+ * See ADR-010 and the "UI Test IDs" guide for the rationale and conventions.
+ *
+ * Conventions:
+ * - kebab-case values,
+ * - hierarchical `<area>-<component>-<element>`,
+ * - suffix by element type where helpful (`-btn`, `-input`, `-select`, ...).
+ *
+ * Templates must reference these constants instead of inlining raw strings:
+ *
+ *   <v-btn :data-test="testIds.nwk.createDialogOpenBtn" />
+ *
+ * Reusable wrapper components carry a fixed value; this is safe because two
+ * instances of the same wrapper are never visible at the same time.
+ */
+export const testIds = {
+  /** Global application shell: app bar and navigation drawer. */
+  app: {
+    navToggle: "app-nav-toggle",
+    homeLogo: "app-home-logo",
+    homeTitle: "app-home-title",
+  },
+  /** Navigation drawer entries. */
+  nav: {
+    nachwuchskraefte: "nav-nachwuchskraefte",
+    meldezeitraum: "nav-meldezeitraum",
+    praktikumsplaetze: "nav-praktikumsplaetze",
+    zuweisung: "nav-zuweisung",
+  },
+  /** Main / landing view. */
+  main: {
+    cardNachwuchskraefte: "main-card-nachwuchskraefte",
+    cardMeldezeitraum: "main-card-meldezeitraum",
+    cardPraktikumsplaetze: "main-card-praktikumsplaetze",
+    cardZuweisung: "main-card-zuweisung",
+  },
+  /** Global feedback components. */
+  feedback: {
+    snackbar: "snackbar",
+    snackbarCloseBtn: "snackbar-close-btn",
+    errorDialog: "error-dialog",
+    errorDialogCloseBtn: "error-dialog-close-btn",
+  },
+  /** Shared/common building blocks. */
+  common: {
+    pageTitle: "page-title",
+    pageTitleBackBtn: "page-title-back-btn",
+    dataTable: "data-table",
+    dataTableSearch: "data-table-search",
+    dataTableGroupBy: "data-table-group-by",
+    datePickerField: "date-picker-field",
+  },
+  /** Generic dialogs (YesNo / TwoChoice / Warning). */
+  dialog: {
+    yesNoActivatorBtn: "yesno-dialog-activator-btn",
+    yesNoNoBtn: "yesno-dialog-no-btn",
+    yesNoYesBtn: "yesno-dialog-yes-btn",
+    twoChoiceActivatorBtn: "two-choice-dialog-activator-btn",
+    twoChoiceOne: "two-choice-dialog-choice-one",
+    twoChoiceTwo: "two-choice-dialog-choice-two",
+    twoChoiceCloseBtn: "two-choice-dialog-close-btn",
+    warningAcceptBtn: "warning-dialog-accept-btn",
+    warningRejectBtn: "warning-dialog-reject-btn",
+  },
+  /** Nachwuchskraefte view and its dialogs/inputs. */
+  nwk: {
+    createDialogOpenBtn: "nwk-create-dialog-open-btn",
+    createDialog: "nwk-create-dialog",
+    updateDialogOpenBtn: "nwk-update-dialog-open-btn",
+    updateDialog: "nwk-update-dialog",
+    cancelBtn: "nwk-cancel-btn",
+    acceptBtn: "nwk-accept-btn",
+    vornameInput: "nwk-vorname-input",
+    nachnameInput: "nwk-nachname-input",
+    jahrgangInput: "nwk-jahrgang-input",
+    vorlesungstageSelect: "nwk-vorlesungstage-select",
+    richtungSelect: "nwk-richtung-select",
+    excelImportOpenBtn: "nwk-excel-import-open-btn",
+    excelImportDialog: "nwk-excel-import-dialog",
+    excelImportFileInput: "nwk-excel-import-file-input",
+    excelImportCancelBtn: "nwk-excel-import-cancel-btn",
+    excelImportUploadBtn: "nwk-excel-import-upload-btn",
+  },
+  /** Meldezeitraeume view, list and creation dialog. */
+  meldezeitraum: {
+    createOpenBtn: "meldezeitraum-create-open-btn",
+    createDialog: "meldezeitraum-create-dialog",
+    nameInput: "meldezeitraum-name-input",
+    startInput: "meldezeitraum-start-input",
+    endInput: "meldezeitraum-end-input",
+    backBtn: "meldezeitraum-back-btn",
+    saveBtn: "meldezeitraum-save-btn",
+    listCard: "meldezeitraum-list-card",
+    deleteBtn: "meldezeitraum-delete-btn",
+  },
+  /** Praktikumsstelle (Meldung + overview + edit/delete). */
+  praktikumsstelle: {
+    editBtn: "praktikumsstelle-edit-btn",
+    deleteBtn: "praktikumsstelle-delete-btn",
+    editDialog: "praktikumsstelle-edit-dialog",
+    cancelBtn: "praktikumsstelle-cancel-btn",
+    acceptBtn: "praktikumsstelle-accept-btn",
+    saveBtn: "praktikumsstelle-save-btn",
+    // form fields (shared between Studium/Ausbildung meldung and edit dialogs)
+    dienststelleInput: "praktikumsstelle-dienststelle-input",
+    dringlichkeitSelect: "praktikumsstelle-dringlichkeit-select",
+    namentlicheAnforderungInput:
+      "praktikumsstelle-namentliche-anforderung-input",
+    planstelleRadio: "praktikumsstelle-planstelle-radio",
+    projektarbeitRadio: "praktikumsstelle-projektarbeit-radio",
+    taetigkeitenInput: "praktikumsstelle-taetigkeiten-input",
+    studienrichtungSelect: "praktikumsstelle-studienrichtung-select",
+    studiensemesterSelect: "praktikumsstelle-studiensemester-select",
+    ausbildungsrichtungSelect: "praktikumsstelle-ausbildungsrichtung-select",
+    ausbildungsjahrSelect: "praktikumsstelle-ausbildungsjahr-select",
+    programmierkenntnisseSelect:
+      "praktikumsstelle-programmierkenntnisse-select",
+    wuenscheInput: "praktikumsstelle-wuensche-input",
+    ausbilderInput: "praktikumsstelle-ausbilder-input",
+    ausbilderEmailInput: "praktikumsstelle-ausbilder-email-input",
+    fuehrungszeugnisCheckbox: "praktikumsstelle-fuehrungszeugnis-checkbox",
+    minderjaehrigRadio: "praktikumsstelle-minderjaehrig-radio",
+    meldezeitraumSelect: "praktikumsstelle-meldezeitraum-select",
+  },
+  /** Zuweisung view and its cards/dialogs. */
+  assign: {
+    nwkList: "assign-nwk-list",
+    nwkCard: "assign-nwk-card",
+    praktikumsstellenList: "assign-praktikumsstellen-list",
+    praktikumsstelleCard: "assign-praktikumsstelle-card",
+    sendMailsBtn: "assign-send-mails-btn",
+    exportBtn: "assign-export-btn",
+    undeliveredMailsDialog: "assign-undelivered-mails-dialog",
+    undeliveredMailsCloseBtn: "assign-undelivered-mails-close-btn",
+  },
+} as const;
+
+export default testIds;

--- a/praktikumsplaner-frontend/src/views/AssignView.vue
+++ b/praktikumsplaner-frontend/src/views/AssignView.vue
@@ -43,6 +43,7 @@
         :prepend-icon="mdiMail"
         color="primary"
         class="mr-4"
+        :data-test="testIds.assign.sendMailsBtn"
         @click="openMailWarningDialog"
         >Mails senden</v-btn
       >
@@ -79,6 +80,7 @@ import { useWarnings } from "@/composables/warningGenerator";
 import router from "@/plugins/router";
 import emitter from "@/stores/eventBus";
 import { useUserStore } from "@/stores/user";
+import { testIds } from "@/testIds";
 import Nwk from "@/types/Nwk";
 import Praktikumsstelle from "@/types/Praktikumsstelle";
 import Warning from "@/types/Warning";

--- a/praktikumsplaner-frontend/src/views/MainView.vue
+++ b/praktikumsplaner-frontend/src/views/MainView.vue
@@ -23,6 +23,7 @@
           <router-link
             to="nachwuchskraefte"
             class="text-decoration-none"
+            :data-test="testIds.main.cardNachwuchskraefte"
           >
             <v-card class="mx-auto">
               <v-card-title> Nachwuchskräfte anlegen </v-card-title>
@@ -44,6 +45,7 @@
           <router-link
             to="meldezeitraum"
             class="text-decoration-none"
+            :data-test="testIds.main.cardMeldezeitraum"
           >
             <v-card class="mx-auto">
               <v-card-title> Meldezeitraum anlegen </v-card-title>
@@ -65,6 +67,7 @@
           <router-link
             to="praktikumsplaetze"
             class="text-decoration-none"
+            :data-test="testIds.main.cardPraktikumsplaetze"
           >
             <v-card class="mx-auto">
               <v-card-title> Praktikumsplatz melden </v-card-title>
@@ -86,6 +89,7 @@
           <router-link
             to="zuweisung"
             class="text-decoration-none"
+            :data-test="testIds.main.cardZuweisung"
           >
             <v-card class="mx-auto">
               <v-card-title> Zuweisung durchführen </v-card-title>
@@ -133,6 +137,7 @@ import { checkHealth } from "@/api/HealthService";
 import { useSecurity } from "@/composables/security";
 import { useSnackbarStore } from "@/stores/snackbar";
 import { useUserStore } from "@/stores/user";
+import { testIds } from "@/testIds";
 
 const snackbarStore = useSnackbarStore();
 const userStore = useUserStore();

--- a/praktikumsplaner-frontend/src/views/praktikumsplaetze/MeldungAusbildung.vue
+++ b/praktikumsplaner-frontend/src/views/praktikumsplaetze/MeldungAusbildung.vue
@@ -218,6 +218,7 @@
           <v-col class="d-flex justify-end">
             <v-btn
               color="primary"
+              :data-test="testIds.praktikumsstelle.saveBtn"
               @click="uploadPraktikumsstelle"
             >
               speichern
@@ -262,6 +263,7 @@ import WuenscheTooltip from "@/components/praktikumsplaetze/Meldung/WuenscheTool
 import { useSecurity } from "@/composables/security";
 import router from "@/plugins/router";
 import { useUserStore } from "@/stores/user";
+import { testIds } from "@/testIds";
 import Meldezeitraum from "@/types/Meldezeitraum";
 import Praktikumsstelle from "@/types/Praktikumsstelle";
 

--- a/praktikumsplaner-frontend/src/views/praktikumsplaetze/MeldungStudium.vue
+++ b/praktikumsplaner-frontend/src/views/praktikumsplaetze/MeldungStudium.vue
@@ -197,6 +197,7 @@
           <v-col class="d-flex justify-end">
             <v-btn
               color="primary"
+              :data-test="testIds.praktikumsstelle.saveBtn"
               @click="uploadPraktikumsstelle"
             >
               speichern
@@ -237,6 +238,7 @@ import WuenscheTooltip from "@/components/praktikumsplaetze/Meldung/WuenscheTool
 import { useSecurity } from "@/composables/security";
 import router from "@/plugins/router";
 import { useUserStore } from "@/stores/user";
+import { testIds } from "@/testIds";
 import Meldezeitraum from "@/types/Meldezeitraum";
 import Praktikumsstelle from "@/types/Praktikumsstelle";
 


### PR DESCRIPTION
**Description:**

Instrumentiert alle wesentlichen UI-Elemente des Frontends mit `data-test`-Attributen,
damit die UI zuverlässig mit Selenium getestet werden kann. Die Selektoren werden dadurch
stabil gegenüber Restyling, DOM-Refactoring und Vuetify-Upgrades.

- Zentrales, typisiertes Verzeichnis aller Test-IDs in `praktikumsplaner-frontend/src/testIds.ts`
- `data-test` an interaktiven und strukturellen Elementen über alle Bereiche hinweg
  (Navigation, common, nachwuchskraefte, meldezeitraeume, praktikumsplaetze, assign,
  globale Snackbar/Error-Dialoge)
- Namenskonvention: kebab-case, hierarchisch `<area>-<component>-<element>`
- Dokumentation: ADR-010 (Architekturentscheidung) + Guide "UI Test IDs" mit Selenium-Beispielen

Verifiziert: `npm run lint` (Prettier + ESLint + vue-tsc) und `npm test` (48/48) grün.

---
**Definition of Done (DoD):**

- [x] Unittests gepflegt
- [x] Dokumentation ist gepflegt

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Improved support for automated UI testing across key screens and dialogs by adding stable `data-test` markers to navigation, tables, form controls, and common actions.
  * Introduced a consistent set of `data-test` identifiers to make test selection more reliable.
* **Documentation**
  * Added a UI testing guide explaining the `data-test` contract, scope rules, and naming convention.
  * Added an architecture decision record documenting the selected approach.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->